### PR TITLE
explained osc in Glossary - as it was nowhere before

### DIFF
--- a/xml/obs_glossary.xml
+++ b/xml/obs_glossary.xml
@@ -33,6 +33,15 @@
    </para>
   </glossdef>
  </glossentry>
+ <glossentry><glossterm>osc</glossterm>
+  <glossdef>
+   <para>
+    The Command Line Interface to work with an instance of
+    <xref linkend="obs.glos.obs"/> called opensuse-commander with svn
+    like handling. More info: https://github.com/openSUSE/osc
+   </para>
+  </glossdef>
+ </glossentry>
  <glossentry><glossterm>Appliance</glossterm>
   <glossdef>
    <para>


### PR DESCRIPTION
osc - the nice and little tool everybody is "just using" which comes from here https://github.com/openSUSE/osc - is just used in this documentation but never explained - so i added it to the glossary, that people can lookup what osc means, where it lives and where its own repo is.

makes things less complicated for new users to OBS which do not know about everything.

Maybe @lethliel want to add osc2 to glossary and OBS docu, as soon as its ready.

@hennevogel @Ana06 maybe review this :sunglasses: