### PR TITLE
Improve Source Service

### DIFF
--- a/xml/book-obs-reference-guide.xml
+++ b/xml/book-obs-reference-guide.xml
@@ -65,7 +65,7 @@
  <xi:include href="obs_image_templates.xml"/>
 <!-- <xi:include href="obs_build_config.xml"/>-->
  <!-- advanced parts -->
- <xi:include href="obs_source_service.xml"/>
+<!-- <xi:include href="obs_source_service.xml"/>-->
  <xi:include href="obs_multibuild.xml"/>
 <!-- <xi:include href="obs_signing.xml"/>-->
  <!--<xi:include href="obs_product_building.xml"/>-->

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -64,14 +64,8 @@
   <xi:include href="obs_basic_workflow.xml"/>
   <xi:include href="osc_building.xml"/>
 
-  <chapter condition="tbd">
-   <title>Using Source Services</title>
-   <para/>
-   <remark>TBD</remark>
-  </chapter>
-
-<!--  <xi:include href="obs_signing.xml"/>-->
-
+  <xi:include href="obs_source_service.xml"/>
+  <!-- tbd: <xi:include href="obs_signing.xml"/>-->
  </part>
 
  <part condition="tbd">

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -355,12 +355,9 @@
   <para>
    Source services are defined in the <filename>_service</filename> file
    and are either part of the package sources or used project-wide.
-   <remark>toms 2017-08-31: Not sure where this _project belongs; where
-   is this _project package?
-   "It is either part of the package sources
-   or used project-wide when stored inside the <filename>_project</filename>
-   package." </remark>
-   For project-wide services, 
+   Project-wide services are stored under the <uri>_project</uri> package
+   in file <filename>_service</filename>.
+   package
   </para>
   <para> The <filename>_service</filename> file contains a list of services
    which get called in the listed order. Each service can define a list of
@@ -381,7 +378,7 @@
   &lt;service name="update_source" mode="disabled" /&gt;
 &lt;/services&gt;</screen>
   <para>
-   With the example above, the following services are executed in the
+   With the example above, the services above are executed in the
    following order:
   </para>
   <orderedlist>

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -409,11 +409,13 @@
  </sect1>
 
  <sect1 xml:id="sec.obs.sserv.remove">
-  <title>Removing a Source Service Again</title>
+  <title>Removing a Source Service</title>
   <para> Sometimes it is useful to continued to work on generated files
-   manually. In this situation the _service file needs to be dropped, but all
-   generated files need to be committed as standard files. The OBS provides the
-   "mergeservice" command for this. It can also be used via osc by calling
+   manually. In this situation the <filename>_service</filename> file needs
+   to be dropped, but all
+   generated files need to be committed as standard files. The &obsa;
+   provides the <command>mergeservice</command> command for this. It can
+   also be used via &osccmd; by calling
     <command>osc service merge</command>. </para>
  </sect1>
 

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -18,46 +18,65 @@
    combined following the powerful idea of the classic UNIX design.
   </para>
   <para>
-   Design goals of source services were:
+   Source services allow:
   </para>
   <itemizedlist>
    <listitem>
-    <para> server side generated files must be easy to identify and must not be
+    <para>
+     Server side generated files are easy to identify and are not
      modifiable by the user. This way others user can trust them to be
-     generated in the documented way without modifications. </para>
-   </listitem>
-   <listitem>
-    <para> generated files must never create merge conflicts </para>
-   </listitem>
-   <listitem>
-    <para> generated files must be a separate commit to the user change </para>
-   </listitem>
-   <listitem>
-    <para> services must be runnable at any time without user commit </para>
-   </listitem>
-   <listitem>
-    <para> services must be runnable on server and client side in the same way
+     generated in the documented way without modifications.
     </para>
    </listitem>
    <listitem>
-    <para> services must be designed in a safe way. A source checkout and
-     service run must never harm the system of a user. </para>
-   </listitem>
-   <listitem>
-    <para> services shall be designed in a way to avoid unnecessary commits.
-     This means there shall be no time-dependent changes. In case the package
-     already contains the same file, the newly generated file must be dropped.
+    <para>
+     Generated files never create merge conflicts.
     </para>
    </listitem>
    <listitem>
-    <para> local services can be added and used by everybody. </para>
+    <para>
+     Generated files are a separate commit to the user change.
+    </para>
    </listitem>
    <listitem>
-    <para> server side services must be installed by the admin of the OBS
-     server. </para>
+    <para>
+     Services are runnable at any time without user commit.
+    </para>
    </listitem>
    <listitem>
-    <para> service can be defined per package or project wide. </para>
+    <para>
+     Services are runnable on server and client side in the same way.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Services are safe. A source checkout and service run never harms
+     the system of a user.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Services avoid unnecessary commits.
+     This means there are no time-dependent changes. In case the package
+     already contains the same file, the newly generated file are dropped.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Services running local or inside the build environment can get created,
+     added and used by everybody.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Services running in default or server side mode must be installed by
+     the administrator of the &obsa; server.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The use of a service can be defined per package or project wide.
+    </para>
    </listitem>
   </itemizedlist>
   <para>
@@ -67,7 +86,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     An XML file named <filename>_services</filename>.
+     An XML file named <filename>_service</filename>.
     </para>
    </listitem>
    <listitem>
@@ -83,7 +102,7 @@
    </listitem>
   </itemizedlist>
   <example xml:id="ex.obs.sserv.struct">
-   <title>General Structure of a <filename>_service</filename> File</title>
+   <title>Structure of a <filename>_service</filename> File</title>
   <screen language="xml">&lt;services&gt; <co xml:id="co.obs.sserv.struct.services"/>
  &lt;service name="<replaceable>MY_SCRIPT</replaceable>"<co xml:id="co.obs.sserv.struct.name"/> mode="<replaceable>MODE</replaceable>"<co xml:id="co.obs.sserv.struct.mode"/>&gt;
   &lt;param name="<replaceable>PARAMETER1</replaceable>"&gt;<replaceable>PARAMETER1_VALUE</replaceable>&lt;/param&gt;<co xml:id="co.obs.sserv.struct.param"/>
@@ -103,12 +122,12 @@
     </callout>
     <callout arearefs="co.obs.sserv.struct.mode">
      <para>
-      A mode of service, see <xref linkend="sec.obs.sserv.mode"/>.
+      Mode of the service, see <xref linkend="sec.obs.sserv.mode"/>.
      </para>
     </callout>
     <callout arearefs="co.obs.sserv.struct.param">
      <para>
-      One or more parameter which are passed to the script definied in
+      One or more parameters which are passed to the script definied in
       <xref linkend="co.obs.sserv.struct.name"/>.
      </para>
     </callout>
@@ -122,8 +141,8 @@
  </sect1>
 
  <sect1 xml:id="sec.obs.sserv.mode">
-  <title>Different Modes of Services</title>
-  <para> Each service can be used in a special mode defining when it should run
+  <title>Modes of Services</title>
+  <para> Each service can be used in a mode defining when it should run
    and how to use the result. This can be done per package or globally for an
    entire project. </para>
   <variablelist>
@@ -140,7 +159,7 @@
     <term><literal>trylocal</literal> Mode</term>
     <listitem>
      <para>
-      This mode is running the service locally. The result gets committed
+      This mode is running the service locally. The result is committed
       as standard files and not named with a <literal>_service:</literal>
       prefix. Additionally, the service runs on the server by
       default. Usually the service should detect that the result is the same
@@ -154,7 +173,7 @@
     <listitem>
      <para>
       This mode is running the service locally. The result gets committed
-      as standard files and not named  with _service: prefix.
+      as standard files and not named  with <literal>_service:</literal> prefix.
       The service is never running on the server side. It is also not
       possible to trigger it manually.
      </para>
@@ -192,7 +211,7 @@
     <term><literal>disabled</literal> Mode</term>
     <listitem>
      <para>
-      The disabled mode is neither running the service locally or on the
+      The disabled mode is neither running the service locally nor on the
       server side. It can be used to temporarily disable the service but keeping
       the definition as part of the service definition. Or it can be used to
       define the way how to generate the sources and doing so by manually calling
@@ -207,16 +226,16 @@
  <sect1 xml:id="sec.obs.sserv.validate">
   <title>Defining Services for Validation</title>
   <para>
-   Source Services may be used to validate sources. This can be definied
-   as:
+   Source Services can be used to validate sources. This can be defined
+   at different levels:
   </para>
   <itemizedlist>
    <listitem>
     <formalpara>
      <title>Per Package</title>
      <para>
-      Useful when the packager wants to validate the downloaded sources
-      are really from the original maintainer.
+      Useful when the packager wants to validate wheather the downloaded
+      sources are really from the original maintainer.
      </para>
     </formalpara>
    </listitem>
@@ -224,29 +243,43 @@
     <formalpara>
      <title>Per Project</title>
      <para>
-      Useful for applying general policies which cannot get skipped in
+      Useful for applying project-wide policies which cannot be skipped for
       any package.
      </para>
     </formalpara>
    </listitem>
   </itemizedlist>
-  <remark>toms 2017-08-31: Hmn, not sure how to rephrase the following
-  sentence...</remark>
+
   <para>
-   Validation can happen by validating files, for example, using the
-    <systemitem class="service">verify_file</systemitem> or <systemitem
-      class="service">source_validator</systemitem> service.
-   These services just fail in the error case which leads to the build
-   state "broken". Or validation can happen by redoing a certain action and
-   store the result as new file as <command>download_files</command> is doing.
-   In this case the newly generated file will be used instead of the committed
-   one during build. </para>
+   You can validate sources using either of two methods:
+  </para>
+  <remark>toms 2017-09-01: by sknorr regarding the list:
+  however, (based off my interpretation) the use cases seem to be different
+  for those two methods: the first guards against corruptions that happen
+  on the way between maintainer and you (i.e. rogue ISP). the second guards
+  against corruptions between the source project and you (i.e. rogue
+  maintainer). Interestingly, neither guards against both.
+  </remark>
+  <itemizedlist>
+   <listitem>
+    <para>
+     By comparing checksums and metadata of the files in your repository
+     with checksums and metadata as recorded by the maintainer.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Alternatively, you can download the sources from a trusted location
+     again and verify that they did not change.
+    </para>
+   </listitem>
+  </itemizedlist>
  </sect1>
 
  <sect1 xml:id="sec.obs.sserv.create">
   <title>Creating Source Service Definitions</title>
   <para>
-   Source services are definied in the <filename>_service</filename> file
+   Source services are defined in the <filename>_service</filename> file
    and are either part of the package sources or used project-wide.
    <remark>toms 2017-08-31: Not sure where this _project belongs; where
    is this _project package?
@@ -255,7 +288,7 @@
    package." </remark>
   </para>
   <para> The <filename>_service</filename> file contains a list of services
-   which get called in the listed order. Each service may define a list of
+   which get called in the listed order. Each service can define a list of
    parameters and a mode.
    The project wide services get called after the per package defined
    services.
@@ -292,16 +325,16 @@
    </listitem>
    <listitem>
     <para>
-     If enabled, upgrade the source to a newer version available online.
-     This service is usually not executed unless when you run
-     <command>osc service disabledrun</command>.
+     When <command>osc service disabledrun</command> is run manually, update
+     the source archive from an online source. In all other cases, ignore
+     this part of the <filename>_service</filename> file.
     </para>
    </listitem>
   </orderedlist>
  </sect1>
 
- <sect1>
-  <title>Dropping a Source Service Again</title>
+ <sect1 xml:id="sec.obs.sserv.remove">
+  <title>Removing a Source Service Again</title>
   <para> Sometimes it is useful to continued to work on generated files
    manually. In this situation the _service file needs to be dropped, but all
    generated files need to be committed as standard files. The OBS provides the

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -96,7 +96,7 @@
    </listitem>
    <listitem>
     <para>
-     A <tag>service</tag> element which uses the specific services with
+     A <tag>service</tag> element which uses the specific service with
      optional parameters.
     </para>
    </listitem>
@@ -138,6 +138,8 @@
   </para>
   <screen><command>/usr/lib/obs/service/<replaceable
    >MY_SCRIPT</replaceable></command> --<replaceable>PARAMETER1</replaceable> <replaceable>PARAMETER1_VALUE</replaceable> --outdir <replaceable>DIR</replaceable></screen>
+  <remark>toms 2017-09-01: Maybe we should add a list of available
+  services from /usr/lib/obs/service/?</remark>
  </sect1>
 
  <sect1 xml:id="sec.obs.sserv.mode">
@@ -256,6 +258,7 @@
    <varlistentry>
     <term><literal>serveronly</literal> Mode</term>
     <listitem>
+     <remark>toms 2017-09-01: deprecated according to "osc service -h"?</remark>
      <para>
       The serviceonly mode is running the service on the service only. This
       can be useful, when the service is not available or can not work on

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -7,136 +7,263 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
- <title>Source Services</title>
+ <title>Using Source Services</title>
  <info/>
- <para> Source Services are tools to validate, generate or modify sources in a
-  trustable way. They are designed as smallest possible tools and can be
-  combined following the powerful idea of the classic UNIX design. </para>
- <para> Design goals of source services were: </para>
- <itemizedlist>
-  <listitem>
-   <para> server side generated files must be easy to identify and must not
-    be modifiable by the user. This way others user can trust them to be
-    generated in the documented way without modifications. </para>
-  </listitem>
-  <listitem>
-   <para> generated files must never create merge conflicts </para>
-  </listitem>
-  <listitem>
-   <para> generated files must be a separate commit to the user change
-   </para>
-  </listitem>
-  <listitem>
-   <para> services must be runnable at any time without user commit
-   </para>
-  </listitem>
-  <listitem>
-   <para> services must be runnable on server and client side in the same
-    way </para>
-  </listitem>
-  <listitem>
-   <para> services must be designed in a safe way. A source checkout and
-    service run must never harm the system of a user. </para>
-  </listitem>
-  <listitem>
-   <para> services shall be designed in a way to avoid unnecessary commits.
-    This means there shall be no time-dependent changes. In case the package
-    already contains the same file, the newly generated file must be dropped.
-   </para>
-  </listitem>
-  <listitem>
-   <para> local services can be added and used by everybody. </para>
-  </listitem>
-  <listitem>
-   <para> server side services must be installed by the admin of the OBS
-    server. </para>
-  </listitem>
-  <listitem>
-   <para> service can be defined per package or project wide. </para>
-  </listitem>
- </itemizedlist>
- <sect1>
-  <title>Using Services for Validation</title>
-  <para> Source Services may be used to validate sources. This can happen per
-   package, which is useful when the packager wants to validate that downloaded
-   sources are really from the original maintainer. Or validation can happen
-   for an entire project to apply general policies. These services cannot get
-   skipped in any package </para>
-  <para> Validation can happen by validating files (for example using the
-    <command>verify_file</command> or <command>source_validator</command>
-   service. These services just fail in the error case which leads to the build
+
+ <sect1 xml:id="sec.obs.sserv.about">
+  <title>About Source Service</title>
+  <para>
+   Source Services are tools to validate, generate or modify sources in a
+   trustable way. They are designed as smallest possible tools and can be
+   combined following the powerful idea of the classic UNIX design.
+  </para>
+  <para>
+   Design goals of source services were:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para> server side generated files must be easy to identify and must not be
+     modifiable by the user. This way others user can trust them to be
+     generated in the documented way without modifications. </para>
+   </listitem>
+   <listitem>
+    <para> generated files must never create merge conflicts </para>
+   </listitem>
+   <listitem>
+    <para> generated files must be a separate commit to the user change </para>
+   </listitem>
+   <listitem>
+    <para> services must be runnable at any time without user commit </para>
+   </listitem>
+   <listitem>
+    <para> services must be runnable on server and client side in the same way
+    </para>
+   </listitem>
+   <listitem>
+    <para> services must be designed in a safe way. A source checkout and
+     service run must never harm the system of a user. </para>
+   </listitem>
+   <listitem>
+    <para> services shall be designed in a way to avoid unnecessary commits.
+     This means there shall be no time-dependent changes. In case the package
+     already contains the same file, the newly generated file must be dropped.
+    </para>
+   </listitem>
+   <listitem>
+    <para> local services can be added and used by everybody. </para>
+   </listitem>
+   <listitem>
+    <para> server side services must be installed by the admin of the OBS
+     server. </para>
+   </listitem>
+   <listitem>
+    <para> service can be defined per package or project wide. </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   For using source services you need (refer to <xref
+    linkend="ex.obs.sserv.struct"/>):
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     An XML file named <filename>_services</filename>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A root element <tag>services</tag>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A <tag>service</tag> element which uses the specific services with
+     optional parameters.
+    </para>
+   </listitem>
+  </itemizedlist>
+  <example xml:id="ex.obs.sserv.struct">
+   <title>General Structure of a <filename>_service</filename> File</title>
+  <screen language="xml">&lt;services&gt; <co xml:id="co.obs.sserv.struct.services"/>
+ &lt;service name="<replaceable>MY_SCRIPT</replaceable>"<co xml:id="co.obs.sserv.struct.name"/> mode="<replaceable>MODE</replaceable>"<co xml:id="co.obs.sserv.struct.mode"/>&gt;
+  &lt;param name="<replaceable>PARAMETER1</replaceable>"&gt;<replaceable>PARAMETER1_VALUE</replaceable>&lt;/param&gt;<co xml:id="co.obs.sserv.struct.param"/>
+ &lt;/service&gt;
+&lt;/services&gt;</screen>
+   <calloutlist>
+    <callout arearefs="co.obs.sserv.struct.services">
+     <para>
+      The root element of a <filename>_service</filename> file.
+     </para>
+    </callout>
+    <callout arearefs="co.obs.sserv.struct.name">
+     <para>
+      The service name. The service is a script that is stored in the
+      <filename>/usr/lib/obs/service</filename> directory.
+     </para>
+    </callout>
+    <callout arearefs="co.obs.sserv.struct.mode">
+     <para>
+      A mode of service, see <xref linkend="sec.obs.sserv.mode"/>.
+     </para>
+    </callout>
+    <callout arearefs="co.obs.sserv.struct.param">
+     <para>
+      One or more parameter which are passed to the script definied in
+      <xref linkend="co.obs.sserv.struct.name"/>.
+     </para>
+    </callout>
+   </calloutlist>
+  </example>
+  <para>
+   The example above will execute the script:
+  </para>
+  <screen><command>/usr/lib/obs/service/<replaceable
+   >MY_SCRIPT</replaceable></command> --<replaceable>PARAMETER1</replaceable> <replaceable>PARAMETER1_VALUE</replaceable> --outdir <replaceable>DIR</replaceable></screen>
+ </sect1>
+
+ <sect1 xml:id="sec.obs.sserv.mode">
+  <title>Different Modes of Services</title>
+  <para> Each service can be used in a special mode defining when it should run
+   and how to use the result. This can be done per package or globally for an
+   entire project. </para>
+  <variablelist>
+   <varlistentry>
+    <term>Default Mode</term>
+    <listitem>
+     <para>
+      The default mode of a service is to always run after each commit on
+      the server side and locally before every local build.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>trylocal</literal> Mode</term>
+    <listitem>
+     <para>
+      This mode is running the service locally. The result gets committed
+      as standard files and not named with a <literal>_service:</literal>
+      prefix. Additionally, the service runs on the server by
+      default. Usually the service should detect that the result is the same
+      and skip the generated files. In case they differ, they get generated
+      and added on the server.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>localonly</literal> Mode</term>
+    <listitem>
+     <para>
+      This mode is running the service locally. The result gets committed
+      as standard files and not named  with _service: prefix.
+      The service is never running on the server side. It is also not
+      possible to trigger it manually.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>serveronly</literal> Mode</term>
+    <listitem>
+     <para>
+      The serviceonly mode is running the service on the service only. This
+      can be useful, when the service is not available or can not work on
+      developer workstations.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>buildtime</literal> Mode</term>
+    <listitem>
+     <para>
+      The service is running inside of the build job, both for local and
+      server side builds. A side effect is that the service package is
+      becoming a build dependency and must be available. Every user can
+      provide and use a service this way in their projects. The generated
+      sources are not part of the source repository, but part of the
+      generated source packages.
+      Note that services requiring external network access are likely to
+      fail in this mode, because such access is not available if the build
+      workers are running in secure mode<phrase
+       os="opensuse;novell"> (as is always the case at <link
+        xlink:href="https://build.opensuse.org"/>)</phrase>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>disabled</literal> Mode</term>
+    <listitem>
+     <para>
+      The disabled mode is neither running the service locally or on the
+      server side. It can be used to temporarily disable the service but keeping
+      the definition as part of the service definition. Or it can be used to
+      define the way how to generate the sources and doing so by manually calling
+      <command>osc service disabledrun</command> The result will
+      get committed as standard files again.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect1>
+
+ <sect1 xml:id="sec.obs.sserv.validate">
+  <title>Defining Services for Validation</title>
+  <para>
+   Source Services may be used to validate sources. This can be definied
+   as:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <formalpara>
+     <title>Per Package</title>
+     <para>
+      Useful when the packager wants to validate the downloaded sources
+      are really from the original maintainer.
+     </para>
+    </formalpara>
+   </listitem>
+   <listitem>
+    <formalpara>
+     <title>Per Project</title>
+     <para>
+      Useful for applying general policies which cannot get skipped in
+      any package.
+     </para>
+    </formalpara>
+   </listitem>
+  </itemizedlist>
+  <remark>toms 2017-08-31: Hmn, not sure how to rephrase the following
+  sentence...</remark>
+  <para>
+   Validation can happen by validating files, for example, using the
+    <systemitem class="service">verify_file</systemitem> or <systemitem
+      class="service">source_validator</systemitem> service.
+   These services just fail in the error case which leads to the build
    state "broken". Or validation can happen by redoing a certain action and
    store the result as new file as <command>download_files</command> is doing.
    In this case the newly generated file will be used instead of the committed
    one during build. </para>
  </sect1>
- <sect1>
-  <title>Different Modes of Services</title>
-  <para> Each service can be used in a special mode defining when it should run
-   and how to use the result. This can be done per package or globally for an
-   entire project. </para>
-  <sect2>
-   <title>Default Mode</title>
-   <para> The default mode of a service is to always run after each commit on
-    the server side and locally before every local build. </para>
-  </sect2>
-  <sect2>
-   <title><literal>trylocal</literal> Mode</title>
-   <para> The trylocal mode is running the service locally when using current
-    osc versions. The result gets committed as standard files and not named
-    with _service: prefix. Additionally the service runs on the server by
-    default, but usually the service should detect that the result is the same
-    and skip the generated files. In case they differ for any reason (because
-    the Web UI or API was used for example), they get generated and added on
-    the server. </para>
-  </sect2>
-  <sect2>
-   <title><literal>localonly</literal> Mode</title>
-   <para> The localonly mode is running the service locally when using current
-    osc versions. The result gets committed as standard files and not named
-    with _service: prefix. The service is never running on the server side. It
-    is also not possible to trigger it manually. </para>
-  </sect2>
-  <sect2>
-   <title><literal>serveronly</literal> Mode</title>
-   <para> The serviceonly mode is running the service on the service only. This
-    can be useful, when the service is not available or can not work on
-    developer workstations. </para>
-  </sect2>
-  <sect2>
-   <title><literal>buildtime</literal> Mode</title>
-   <para> The service is running inside of the build job, for local and server
-    side builds. A side effect is that the service package is becoming a build
-    dependency and must be available. Every user can provide and use a service
-    this way in their projects. The generated sources are not part of the
-    source repository, but part of the generated source packages. Note that
-    services requiring external network access are likely to fail in this mode,
-    because such access is not available if the build workers are running in
-    secure mode<phrase os="opensuse;novell"> (as is always the case at <link
-      xlink:href="https://build.opensuse.org"/>)</phrase>. </para>
-  </sect2>
-  <sect2>
-   <title><literal>disabled</literal> Mode</title>
-   <para> The disabled mode is neither running the service locally or on the
-    server side. It can be used to temporarily disable the service but keeping
-    the definition as part of the service definition. Or it can be used to
-    define the way how to generate the sources and doing so by manually calling
-    <command>osc service disabledrun</command> The result will
-    get committed as standard files again. </para>
-  </sect2>
- </sect1>
- <sect1>
-  <title>Storage of Source Service Definitions</title>
-  <para> The called services are always defined in a
-    <command>_service</command> file. It is either part of the package sources
-   or used project-wide when stored inside the <command>_project</command>
-   package. </para>
-  <para> The _service file contains a list of services which get called in this
-   order. Each service may define a list of parameters and a mode. The project
-   wide services get called after the per package defined services. The
-   _service file is an XML file like this example:</para>
-   <screen>
-&lt;services&gt;
+
+ <sect1 xml:id="sec.obs.sserv.create">
+  <title>Creating Source Service Definitions</title>
+  <para>
+   Source services are definied in the <filename>_service</filename> file
+   and are either part of the package sources or used project-wide.
+   <remark>toms 2017-08-31: Not sure where this _project belongs; where
+   is this _project package?
+   "It is either part of the package sources
+   or used project-wide when stored inside the <filename>_project</filename>
+   package." </remark>
+  </para>
+  <para> The <filename>_service</filename> file contains a list of services
+   which get called in the listed order. Each service may define a list of
+   parameters and a mode.
+   The project wide services get called after the per package defined
+   services.
+   </para>
+  <para>
+   The file is in XML format like this example:
+  </para>
+  <screen>&lt;services&gt;
   &lt;service name="download_files" mode="trylocal" /&gt;
   &lt;service name="verify_file"&gt;
     &lt;param name="file"&gt;krabber-1.0.tar.gz&lt;/param&gt;
@@ -144,17 +271,35 @@
     &lt;param name="checksum"&gt;7f535a96a834b31ba2201a90c4d365990785dead92be02d4cf846713be938b78&lt;/param&gt;
   &lt;/service&gt;
   &lt;service name="update_source" mode="disabled" /&gt;
-&lt;/services&gt;
-</screen>
-   <para>This example downloads the files via download_files service via the given
-   URLs from the spec file. When using osc this file gets committed as part of
-   the commit. Afterwards the krabber-1.0.tar.gz file will always be compared
-   with the sha256 checksum. And last but not least there is the
-    <command>update_source</command> service mentioned, which is usually not
-   executed. Except when <command>osc service disabledrun</command> is called,
-   which will try to upgrade the package to a newer source version available
-   online. </para>
+&lt;/services&gt;</screen>
+  <para>
+   With the example above, the following services are executed in the
+   following order:
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     Downloads the file via the <systemitem>download_files</systemitem>
+     service using the URL from the Spec file.
+     When using osc, the downloaded file gets committed as part of the commit.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Compares the downloaded file (<filename>krabber-1.0.tar.gz</filename>)
+     against the SHA256 checksum.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     If enabled, upgrade the source to a newer version available online.
+     This service is usually not executed unless when you run
+     <command>osc service disabledrun</command>.
+    </para>
+   </listitem>
+  </orderedlist>
  </sect1>
+
  <sect1>
   <title>Dropping a Source Service Again</title>
   <para> Sometimes it is useful to continued to work on generated files
@@ -163,25 +308,7 @@
    "mergeservice" command for this. It can also be used via osc by calling
     <command>osc service merge</command>. </para>
  </sect1>
- <sect1>
-  <title>Defining a Source Service</title>
-  <para>
-   To define a source service add a <tag>service</tag> section to the
-    <filename>_service</filename> file of the project. Within this section,
-   define a script and its arguments that will be called by the source service.
-   The script needs to reside in <filename>/usr/lib/obs/service</filename>.
-  </para>
- <screen>&lt;services&gt;
- &lt;service name="<replaceable>MY_SCRIPT</replaceable>"&gt;
-  &lt;param name="<replaceable>PARAMETER1</replaceable>"&gt;<replaceable>PARAMETER1_VALUE</replaceable>&lt;/param&gt;
- &lt;/service&gt;
-&lt;/services&gt;</screen>
-  <para>
-   The example above will execute the following command:
-  </para>
-  <screen>/usr/lib/obs/service/ <replaceable>MY_SCRIPT</replaceable> \
---<replaceable>PARAMETER1</replaceable> <replaceable>PARAMETER1_VALUE</replaceable> --outdir <replaceable>DIR</replaceable></screen>
- </sect1>
+
  <sect1 condition="tbd">
   <title>Interfaces for Using Source Services</title>
   <para><remark>tbd</remark></para>

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -145,6 +145,80 @@
   <para> Each service can be used in a mode defining when it should run
    and how to use the result. This can be done per package or globally for an
    entire project. </para>
+<!--
+   toms 2017-09-01:
+   This is the table for the variablelist below. It's a good idea, but
+   this table raises more question than it solves.
+   Commenting for the time being.
+  <table>
+   <title>Service Modes</title>
+   <tgroup cols="4">
+    <colspec colnum="1" colwidth="1*"/>
+    <colspec colnum="2" colwidth="2*"/>
+    <colspec colnum="3" colwidth="2*"/>
+    <colspec colnum="4" colwidth="4*"/>
+    <thead>
+     <row>
+      <entry>Mode</entry>
+      <entry>Runs locally</entry>
+      <entry>Runs remotely</entry>
+      <entry>Added File Handling</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>Default</entry>
+      <entry>Before each build</entry>
+      <entry>After each commit</entry>
+      <entry>Generated file, prefixed with <filename>_service:</filename></entry>
+     </row>
+     <row>
+      <entry><literal>trylocal</literal></entry>
+      <entry>Before each build</entry>
+      <entry>After each commit<remark>toms 2017-09-01: True?</remark>
+      </entry>
+      <entry>Committed as standard files but not named with 
+       a <filename>_service:</filename> prefix</entry>
+     </row>
+     <row>
+      <entry><literal>localonly</literal></entry>
+      <entry>Before each build</entry>
+      <entry>Never</entry>
+      <entry>Committed as standard files but not named with 
+       a <filename>_service:</filename> prefix</entry>
+     </row>
+     <row>
+      <entry><literal>serveronly</literal></entry>
+      <entry>Never</entry>
+      <entry>Before each build</entry>
+      <entry>Generated file, prefixed with <filename>_service:</filename><footnote>
+       <para>
+        This can be useful, when the service is not available or can not
+        work on developer workstations.
+       </para>
+      </footnote><remark>toms 2017-09-01: ???</remark></entry>
+     </row>
+     <row>
+      <entry><literal>buildtime</literal></entry>
+      <entry>Before each build<footnote xml:id="fn.obs.sserv.mode.buildtime">
+       <para>
+        A side effect is that the service package is becoming a build
+        dependency and must be available.
+       </para>
+      </footnote></entry>
+      <entry>Before each build<xref linkend="fn.obs.sserv.mode.buildtime"/></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><literal>disabled</literal></entry>
+      <entry>Never</entry>
+      <entry>Never</entry>
+      <entry><remark>toms 2017-09-01: </remark></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+-->
   <variablelist>
    <varlistentry>
     <term>Default Mode</term>
@@ -286,6 +360,7 @@
    "It is either part of the package sources
    or used project-wide when stored inside the <filename>_project</filename>
    package." </remark>
+   For project-wide services, 
   </para>
   <para> The <filename>_service</filename> file contains a list of services
    which get called in the listed order. Each service can define a list of
@@ -294,7 +369,7 @@
    services.
    </para>
   <para>
-   The file is in XML format like this example:
+   The <filename>_service</filename> file is in XML format and looks like this:
   </para>
   <screen>&lt;services&gt;
   &lt;service name="download_files" mode="trylocal" /&gt;

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -371,7 +371,7 @@
   <para>
    The <filename>_service</filename> file is in XML format and looks like this:
   </para>
-  <screen>&lt;services&gt;
+  <screen language="xml">&lt;services&gt;
   &lt;service name="download_files" mode="trylocal" /&gt;
   &lt;service name="verify_file"&gt;
     &lt;param name="file"&gt;krabber-1.0.tar.gz&lt;/param&gt;

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -24,7 +24,7 @@
    <listitem>
     <para>
      Server side generated files are easy to identify and are not
-     modifiable by the user. This way others user can trust them to be
+     modifiable by the user. This way other user can trust them to be
      generated in the documented way without modifications.
     </para>
    </listitem>
@@ -308,7 +308,7 @@
     <formalpara>
      <title>Per Package</title>
      <para>
-      Useful when the packager wants to validate wheather the downloaded
+      Useful when the packager wants to validate whether the downloaded
       sources are really from the original maintainer.
      </para>
     </formalpara>
@@ -327,7 +327,7 @@
   <para>
    You can validate sources using either of two methods:
   </para>
-  <remark>toms 2017-09-01: by sknorr regarding the list:
+  <remark>toms 2017-09-01: by sknorr FIXME: regarding the list:
   however, (based off my interpretation) the use cases seem to be different
   for those two methods: the first guards against corruptions that happen
   on the way between maintainer and you (i.e. rogue ISP). the second guards


### PR DESCRIPTION
I've restructured this chapter and try to improve the structure. Here are the changes:

* Introduce an "About Source Service"
* Give an example with callouts
* Add xml:id's
* Convert sect2 into variablelist entries
* Change order of some sect1s

I'm not completely satisfied with the result yet, but it's a first start. 