### PR TITLE
Document cloud upload issue related to system time

### DIFF
--- a/xml/obs_ag_installation_and_configuration.xml
+++ b/xml/obs_ag_installation_and_configuration.xml
@@ -320,6 +320,13 @@ systemctl start obsclouduploadserver.service
         </screen>
         Read more about configuring the backend in <xref linkend="_distributed_setup"/>.
       </para>
+      <warning>
+        <para>
+          Ensure that the system time of your cloud uploader instance is correct.
+          AWS is relying on the timestamps of the requests it receives.
+          Having an incorrect system time will cause cloud uploads to fail.
+        </para>
+      </warning>
     </sect4>
     <sect4 xml:id="_aws_authentication_credential_setup">
       <title>AWS authentication – Credentials setup</title>


### PR DESCRIPTION
Having a wrong system time on the cloud uploader instance can lead
to failures during the upload.

https://github.com/openSUSE/open-build-service/issues/4633