### PR TITLE
Minor documentation update.

### DIFF
--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -572,7 +572,7 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
       baseform="Working Directory">working directory</firstterm>:
     </para>
     <screen>&prompt.user;<command>cd</command> &obsworkdir1;
-&prompt.user;<command>osc</command> mkpac example-osc</screen>
+&prompt.user;<command>osc</command> mkpac &gitproject;</screen>
    </step>
    <step>
     <para>
@@ -727,7 +727,7 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
     </example>
     <para>
      <remark>toms 2017-08-17: FIXME: Better link to OBS instead of GH?</remark>
-     For the complete spec file, see <link xlink:href="&gitupstream1;"/>.
+     For the complete spec file, see <link xlink:href="&referencespec;"/>.
     </para>
    </step>
    <step>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -68,6 +68,7 @@
 <!ENTITY gitproject     "my-first-obs-package">
 <!ENTITY gitprjvers     "0.1.0">
 <!ENTITY gitupstream1   "https://github.com/&gitorg;/&gitproject;">
+<!ENTITY referencespec  "&obsrepoviewfile;&obshome1;/&gitproject;/&gitproject;.spec">
 
 
 <!-- ============================================================= -->


### PR DESCRIPTION
- Changed the name of the package to the name of the git project.
- Changed link to the reference spec to point to the one on OBS.

Note: I wasn't able to run daps to validate these changes, it complained about not finding the stylesheet. I assume this is because they're not available on Fedora. I'm going to set up a VM and see if it'll work there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensuse/obs-docu/99)
<!-- Reviewable:end -->
