### PR TITLE
fix serveronly mode documentation

### DIFF
--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -260,7 +260,7 @@
     <listitem>
      <remark>toms 2017-09-01: deprecated according to "osc service -h"?</remark>
      <para>
-      The serviceonly mode is running the service on the server only. This
+      The serveronly mode is running the service on the server only. This
       can be useful, when the service is not available or can not work on
       developer workstations.
      </para>

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -258,7 +258,6 @@
    <varlistentry>
     <term><literal>serveronly</literal> Mode</term>
     <listitem>
-     <remark>toms 2017-09-01: deprecated according to "osc service -h"?</remark>
      <para>
       The serveronly mode is running the service on the server only. This
       can be useful, when the service is not available or can not work on


### PR DESCRIPTION
Fix a typo and an incorrect remark resulting from confusion caused by https://github.com/openSUSE/osc/issues/282.