### PR TITLE
Fixed naming for repo-specific spec-files in obs_multibuild

### DIFF
--- a/xml/obs_multibuild.xml
+++ b/xml/obs_multibuild.xml
@@ -32,8 +32,8 @@
     <listitem>
      <para> Specific files can be created to be built for a specific
       repository. Append the repository name of the build container behind the
-      suffix with a dot. For example
-       <command>hello.spec.openSUSE_13.2</command>. </para>
+      package name with a -. For example
+       <command>hello-openSUSE_13.2.spec</command>. </para>
     </listitem>
    </orderedlist>
  </sect1>


### PR DESCRIPTION
The spec-file has to include the repository name before the
file-extension directly behind the package name with a -

This should be the line from bs_srcserver source:
    @files = grep {/^\Q$packid-$repoid\E/i} @files if @files > 1;