### PR TITLE
Change example for building books since DC-obs-beginners-guide doesn't exist anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Publishing Suite ([daps](https://github.com/openSUSE/daps)).
 After editing the document validate your changes via the following
 commands, for example:
 
-    $ daps -d DC-obs-beginners-guide validate
+    $ daps -d DC-obs-user-guide validate
 
 Similar for other guides. HTML documentation can get generated via
 
-    $ daps -d DC-obs-beginners-guide html
+    $ daps -d DC-obs-user-guide html
 
 ## Development Environment
 We are also shipping a [docker/docker-compose](https://www.docker.com/) based


### PR DESCRIPTION
Using the daps example as shown in README.md results in [error](https://github.com/openSUSE/obs-docu/issues/139) because the file DC-obs-beginners-guide doesn't exist anymore.

Changing it to DC-obs-user-guide, which exists.