### PR TITLE
Add Github Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Info
+      run: |
+        env | sort
+
+    - name: Build container
+      run: |
+        sed "s/REPLACE_THIS_WITH_YOUR_ID/`id -u`/" docker-compose.override.yml.example > docker-compose.override.yml
+        docker-compose build
+
+    - name: Validate
+      run: |
+        docker-compose run --rm obs-docu daps -d DC-obs-all validate
+
+    - name: Generate HTML
+      run: |
+        docker-compose run --rm obs-docu daps -vv -d DC-obs-all html
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: obs-docu-html
+        path: build/obs-all/html/obs-all/


### PR DESCRIPTION
This will add a Github Workflow which:
* builds the container
* validates the xml
* generates HTML
* uploads HTML as an artifact for easy inspection, so you don't need to build locally to review a PR

An example run can be found in my fork:
https://github.com/perlpunk/obs-docu/actions/runs/518327457

