### PR TITLE
Add chapter about the published container registry 

### DIFF
--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -96,7 +96,7 @@
  <xi:include href="obs_architecture.xml"/>
  <xi:include href="obs_concepts.xml"/>
  <xi:include href="obs_build_process.xml"/>
- <!-- <xi:include href="obs_build_containers.xml"/>-->
+ <xi:include href="obs_build_containers.xml"/>
  <xi:include href="obs_source_management.xml"/>
  <xi:include href="obs_supported_formats.xml"/>
  <xi:include href="obs_request_and_review_system.xml"/>

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -23,8 +23,6 @@
   Things to describe:
 
   From Blogs:
-  * Open Build Service and SUSE Studio Integration
-    https://www.suse.com/communities/blog/suse-studio-integration/
   * Open Build Service – Create Your Own Image Template!
     https://www.suse.com/communities/blog/open-build-service-create-image-template/
 

--- a/xml/obs_build_containers.xml
+++ b/xml/obs_build_containers.xml
@@ -72,7 +72,7 @@
     <term>Flatpak</term>
     <listitem>
      <para>Flatpak packages can be built in the Open Build Service, see
-     &flatpak; for further details.</para>
+     <xref linkend="sec.pkgfmt.flatpak"/> for further details.</para>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/xml/obs_build_containers.xml
+++ b/xml/obs_build_containers.xml
@@ -17,7 +17,7 @@
   the workload independent of the running host OS. This includes (but is not
   limited to) libraries, executables and shared resource files. </para>
 
- <sect1>
+ <sect1 xml:id="_supported_formats">
   <title>Supported Container Formats</title>
   <para> A container that is providing its own kernel is commonly called a
   virtual machine and will be referred to as such in this book. The Open Build
@@ -93,7 +93,7 @@
   </sect2>-->
  </sect1>
 
- <sect1>
+ <sect1 xml:id="_container_registry">
    <title>
      Container Registry
    </title>
@@ -159,7 +159,7 @@
    </para>
  </sect1>
 
- <sect1>
+ <sect1 xml:id="_image_signatures">
    <title>
      Container Image Signatures
    </title>

--- a/xml/obs_build_containers.xml
+++ b/xml/obs_build_containers.xml
@@ -11,37 +11,38 @@
  <info>
   <abstract>
    <para/>
-   <remark>TBD</remark>
   </abstract>
  </info>
- <para> Containers are workloads which container all necessary files to make
+ <para> Containers are workloads which embed all necessary files to make
   the workload independent of the running host OS. This includes (but is not
   limited to) libraries, executables and shared resource files. </para>
 
  <sect1>
-  <title>Supported Containers</title>
-  <para> A container that is providing its own kernel is called virtual machine
-   in this book. Open Build Service (OBS) supports container builds either by
-   supporting the native build format or as side product of a different format.
-   The range is from very simple chroot containers via server format (for example,
-   Docker) or desktop format (for example, AppImage or Snap) up to full VM builds
-   (such as for OpenStack, KVM, or as a LiveCD via kiwi). </para>
+  <title>Supported Container Formats</title>
+  <para> A container that is providing its own kernel is commonly called a
+  virtual machine and will be referred to as such in this book. The Open Build
+  Service (OBS) supports container builds either by supporting the native build
+  format or as side product of a different format.  This ranges is from very
+  simple chroot containers over server (for example, Docker) or desktop formats
+  (for example, AppImages, Snaps or Flatpaks) up to full VM builds (such as for
+  OpenStack, KVM, or as a Live CD via &kiwi;). </para>
 
   <variablelist>
    <varlistentry>
     <term>SimpleImage</term>
     <listitem>
-     <para> SimpleImage is a special format which is using rpm spec file syntax
-    and just packages the resulting install root as tar ball or squashfs image.
-    The format is just using the BuildRequires tags inside of a file called
-    "simpleimage", it supports also rpm macro handling to allow to define
-    exceptions depending on the build environment. </para>
+     <para> SimpleImage is a special format which uses the rpm spec file syntax
+     and just packages the resulting install root as tar ball or squashfs image.
+     The format is just using the BuildRequires tags from a file called
+     <filename>simpleimage</filename>, it supports also rpm macro handling to allow
+     for exceptions depending on the build environment. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Docker</term>
     <listitem>
-     <para>Docker images are currently only supported via the &kiwi; tool.</para>
+     <para>Docker images can be built either via the &kiwi; tool or from
+     Dockerfiles.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -70,8 +71,8 @@
    <varlistentry>
     <term>Flatpak</term>
     <listitem>
-     <para>Flatpak is currently not supported due to the lack of
-    reproducible builds.</para>
+     <para>Flatpak packages can be built in the Open Build Service, see
+     &flatpak; for further details.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -90,5 +91,172 @@
    <title>&kiwi; Product Builds</title>
    <para> </para>
   </sect2>-->
+ </sect1>
+
+ <sect1>
+   <title>
+     Container Registry
+   </title>
+   <para>
+     Container Registries are repositories that container images are published
+     and can be automatically pulled from using tools like <link
+     xlink:href="https://podman.io/">podman</link> or <link
+     xlink:href="https://www.docker.com/">docker</link>.
+   </para>
+   <para>
+     The Open Build Service will automatically publish container images in a
+     OCI-compatible registry, with the URLs to the images constructed as follows:
+     <literal>
+       $BASE/$PROJECT/$REPOSITORY/$IMAGE_NAME:$TAG
+     </literal>
+     with the following components:
+     <itemizedlist>
+       <listitem>
+         <para>
+           <literal>$BASE</literal>: URL/IP under which the Open Build Service
+           instance is reachable
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>$PROJECT</literal>: The name of the project where the image is
+           build, with all colons replaced with forward slashes.
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>$REPOSITORY</literal>: The name of the repository where the
+           containers are published.
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>$IMAGE_NAME</literal>: The name of this container image. It
+           defaults to the name of the package from which the container is
+           build. Alternatively, a different image name can be specified in the
+           build recipe, e.g. via the <literal>containerconfig</literal> element in a
+           &kiwi; file (see <link
+           xlink:href="https://osinside.github.io/kiwi/building_images/build_docker_container.html?highlight=containerconfig">the
+           kiwi documentation</link> for further details).
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>$TAG</literal>: The image tag. This defaults to
+           <literal>latest</literal> with alternatives being provided in a similar
+           fashion as the image's name.
+         </para>
+       </listitem>
+     </itemizedlist>
+   </para>
+   <para>
+     The <link
+     xlink:href="https://github.com/openSUSE/cooverview">cooverview</link>
+     project provides a simple user-facing webpage to search for containers
+     published by the Open Build Service and can be used to conveniently obtain
+     the correct registry URLs. It is used to power <link
+     xlink:href="https://registry.opensuse.org/">registry.opensuse.org</link>
+   </para>
+ </sect1>
+
+ <sect1>
+   <title>
+     Container Image Signatures
+   </title>
+   <para>
+     The Open Build Service automatically signs every package that has been
+     build and publishes the cryptographic signature alongside with
+     it. Container images are no exception to this and the detached signatures
+     can be used by <link xlink:href="https://podman.io/">podman</link> to
+     verify every image that is pulled from the registry.
+   </para>
+   <para>
+     Podman has to be configured first as outlined in the following steps.
+     <itemizedlist>
+       <listitem>
+         <para>
+           Create a <literal>yaml</literal> file under
+           <literal>/etc/containers/registries.d/</literal> with an appropriate
+           name for your instance and the following contents:
+           <example>
+           <title>registry.yaml</title>
+           <screen>
+---
+docker:
+  <replaceable>REGISTRY_URL</replaceable>:
+    sigstore: <replaceable>REGISTRY_URL</replaceable>/sigstore
+           </screen>
+           </example>
+           Replace <replaceable>REGISTRY_URL</replaceable> with the appropriate
+           URL to your instance of &obs; (for example,
+           <literal>registry.opensuse.org</literal>).
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           Add the following object into the key <literal>transports</literal>
+           in the file <filename>/etc/containers/policy.json</filename>:
+           <example>
+           <title>policy.json</title>
+           <screen>
+    "docker": {
+      "<replaceable>REGISTRY_URL</replaceable>": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "<replaceable>PATH_TO_PUBLIC_KEY</replaceable>"
+        }
+      ]
+    }
+           </screen>
+           </example>
+           The complete <filename>/etc/containers/policy.json</filename> can then
+           look like this:
+           <example>
+           <title>policy.json</title>
+           <screen>
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "docker": {
+      "<replaceable>REGISTRY_URL</replaceable>": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "<replaceable>PATH_TO_PUBLIC_KEY</replaceable>"
+        }
+      ]
+    }
+  }
+}
+           </screen>
+           </example>
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           Save the public key of the project where your image is build under
+           <replaceable>PATH_TO_PUBLIC_KEY</replaceable> (you can choose any
+           location to which you have read access, only ensure that you specify
+           it in <filename>/etc/containers/policy.json</filename> as well).
+         </para>
+       </listitem>
+     </itemizedlist>
+   </para>
+   <para>
+     Podman will from now on automatically fetch the published signatures from
+     the backend and verify them before storing the images locally.
+   </para>
  </sect1>
 </chapter>

--- a/xml/obs_package_formats.xml
+++ b/xml/obs_package_formats.xml
@@ -283,7 +283,7 @@ systemctl enable sshd</screen>
   <remark>toms 2017-08-18: TODO What is it and what is needed</remark>
  </sect1>
 
- <sect1>
+ <sect1 xml:id="sec.pkgfmt.flatpak">
   <title>&flatpak;</title>
   <para>
   The <link xlink:href="https://flatpak.org/">Flatpak</link> format can be used


### PR DESCRIPTION
The user guide does not mention the container registry at all, especially that you can use the published gpg signatures with podman for verification. This PR adds a rudimentary guide how to use this feature.

cc @tomschr @adrianschroeter 