### PR TITLE
Document tag_push for event filter in SCM/CI integration

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -643,7 +643,12 @@ workflow:
 
             <listitem>
               <para><emphasis role="bold">push</emphasis> is for push
-              events.</para>
+              events related to commits.</para>
+            </listitem>
+
+            <listitem>
+              <para><emphasis role="bold">tag_push</emphasis> is for push
+              events related to tags.</para>
             </listitem>
           </itemizedlist>
 


### PR DESCRIPTION
Here's a preview of the changes:
![event-filter-obs-docu](https://user-images.githubusercontent.com/1102934/142440554-5a616bad-a8cc-424e-b3dc-b66f1956a14a.png)

You can also review the documentation by checking out this branch and running:

```
docker-compose run obs-docu daps -vv -d DC-obs-all html
```

Once the command is done, open `build/obs-all/html/obs-all/cha.obs.scm_ci_workflow_integration.html` with a web browser.
