### PR TITLE
Document package names with push events for tags

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -296,7 +296,7 @@
           <listitem>
             <para><emphasis role="bold">Trigger:</emphasis> <emphasis>Merge
             request events</emphasis>, <emphasis>Push
-            events</emphasis>.</para>
+              events</emphasis>, <emphasis>Tag push events</emphasis>.</para>
           </listitem>
         </itemizedlist>
       </sect3>
@@ -395,13 +395,18 @@ rebuild_master:
 
           <itemizedlist>
             <listitem>
-              <para>For a pull request event, it will go to e.g.:
+              <para>With a pull request event, it will go to e.g.:
               <emphasis>home:jane:github:jane:ctris:PR-1/ctris</emphasis>. Being <emphasis>PR-1</emphasis> the pull request number.</para>
             </listitem>
 
             <listitem>
-              <para>For a push event, it will go to e.g.:<emphasis>
+              <para>With a push event for commits, it will go to e.g.:<emphasis>
               home:jane/ctris-66f2acfbded89a19935ee6d481b7cf2ab95427f6</emphasis>. Being <emphasis>66f2acfbded89a19935ee6d481b7cf2ab95427f6</emphasis> the SHA of the latest commit that triggered the event.</para>
+            </listitem>
+
+            <listitem>
+              <para>With a push event for tags, it will go to e.g.:<emphasis>
+              home:jane/ctris-release_1</emphasis>. Being <emphasis>release_1</emphasis> the name of the tag that triggered the event.</para>
             </listitem>
           </itemizedlist>
 
@@ -436,8 +441,14 @@ rebuild_master:
 
             <listitem>
               <para><emphasis>home:jane/gcc-fae00a0ac0e5687343a60ae02bf60352002ab9aa</emphasis>
-              for a push event. Being <emphasis>fae00a0ac0e5687343a60ae02bf60352002ab9aa</emphasis>
+              with a push event for commits. Being <emphasis>fae00a0ac0e5687343a60ae02bf60352002ab9aa</emphasis>
               the SHA of the latest commit that triggered the event.</para>
+            </listitem>
+
+            <listitem>
+              <para><emphasis>home:jane/gcc-release_1</emphasis>
+              with a push event for tags. Being <emphasis>release_1</emphasis>
+              the name of the tag that triggered the event.</para>
             </listitem>
           </itemizedlist>
 


### PR DESCRIPTION
For the recent changes in the SCM/CI integration with supporting push events for tags.

Preview of the changes:

First:
![preview_1](https://user-images.githubusercontent.com/1102934/142864460-cc4b1889-4cf9-4d22-818c-bf6bfe7f0162.png)

Second:
![preview_2](https://user-images.githubusercontent.com/1102934/142864463-50b89431-20e5-468a-9d22-828938de208e.png)

Third:
![preview_3](https://user-images.githubusercontent.com/1102934/142864469-af56e34b-3d0b-4b37-bed6-86903fa307b6.png)

You can also review the documentation by checking out this branch and running:

```
docker-compose run obs-docu daps -vv -d DC-obs-all html
```

Once the command is done, open `build/obs-all/html/obs-all/cha.obs.scm_ci_workflow_integration.html` with a web browser.