### PR TITLE
Document paths in configure_repositories for SCM/CI integration

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -492,13 +492,8 @@ rebuild_master:
             </listitem>
 
             <listitem>
-              <para>a target project, e.g.:
-              <emphasis>openSUSE:Factory</emphasis></para>
-            </listitem>
-
-            <listitem>
-              <para>a target repository, e.g.:
-              <emphasis>snapshot</emphasis></para>
+              <para>a list of paths, each having a target project (e.g: <emphasis>openSUSE:Factory</emphasis>)
+                and target repository (e.g: <emphasis>snapshot</emphasis>)</para>
             </listitem>
 
             <listitem>
@@ -517,14 +512,18 @@ rebuild_master:
         project: home:jane
         repositories:
           - name: openSUSE_Tumbleweed
-            target_project: openSUSE:Factory
-            target_repository: snapshot
+            paths:
+              - target_project: openSUSE:Factory
+                target_repository: snapshot
+              - target_project: openSUSE:Tumbleweed
+                target_repository: standard
             architectures:
               - x86_64
               - i586
           - name: openSUSE_Leap_15.2
-            target_project: openSUSE:Leap:15.2
-            target_repository: standard
+            paths:
+              - target_project: openSUSE:Leap:15.2
+                target_repository: standard
             architectures:
               - x86_64</screen>
         </sect4>
@@ -1149,14 +1148,16 @@ workflow:
         project: home:jane:playground
         repositories:
           - name: openSUSE_Tumbleweed
-            target_project: openSUSE:Factory
-            target_repository: snapshot
+            paths:
+              - target_project: openSUSE:Factory
+                target_repository: snapshot
             architectures:
               - x86_64
               - i586
           - name: openSUSE_Leap_15.2
-            target_project: openSUSE:Leap:15.2
-            target_repository: standard
+            paths:
+              - target_project: openSUSE:Leap:15.2
+                target_repository: standard
             architectures:
               - x86_64
   filters:


### PR DESCRIPTION
This isn't live yet, so this should be merged and deployed right before we deploy those changes. This way, users of the `configure_repositories` step know what needs to change when this breaking change is introduced.

To review the changes locally:
1. `docker-compose run --rm obs-docu daps -vv -d DC-obs-all html`
2. `firefox/other_browser build/obs-all/html/obs-all/cha.obs.scm_ci_workflow_integration.html`

Preview of the changes:
![obs-docu-configure_repositories](https://user-images.githubusercontent.com/1102934/151190995-5118794f-82b7-436b-a902-bc440b39b96f.png)
![obs-docu-configure_repositories-2](https://user-images.githubusercontent.com/1102934/151191008-88eab015-4d9d-472c-a50b-edea3fab39cb.png)

