### PR TITLE
Use github actions to deploy obs-docs on obs-landing

### DIFF
--- a/.github/workflows/deploy-to-obs-landing.yaml
+++ b/.github/workflows/deploy-to-obs-landing.yaml
@@ -1,0 +1,63 @@
+name: deploy-to-obs-landing
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/workflows/**'
+      - '!.github/workflows/deploy-to-obs-landing.yaml'
+      - '.travis.yml'
+      - 'Dockerfile'
+      - 'Dockerfile.base'
+      - 'README.md'
+      - 'docker-compose.override.yml.example'
+      - 'docker-compose.yml'
+jobs:
+  build-obs-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH Client
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+      - name: Checkout obs-landing repo
+        uses: actions/checkout@v3
+        with:
+          repository: openSUSE/obs-landing
+          path: obs-landing
+          ssh-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+      - name: build
+        uses: addnab/docker-run-action@v3
+        with:
+          image: openbuildservice/obs-docu:latest
+          options: -v ${{ github.workspace }}:/github/workspace/
+          run: |
+            pushd /github/workspace/
+            for doc in obs-admin-guide obs-user-guide; do
+              source ./DC-$doc || exit 1
+
+              daps --verbosity=3 html || exit 1
+              daps --verbosity=3 epub || exit 1
+              daps --verbosity=3 pdf || exit 1
+
+              rm -rf obs-landing/help/manuals/${doc} || exit 1
+              # update html
+              cp -aL build/${doc}/html/${ROOTID} obs-landing/help/manuals/${doc} || exit 1
+
+              # update epub
+              mv build/${doc}/${ROOTID}_en.epub obs-landing/files/manuals/${doc}.epub || exit 1
+
+              # update pdf
+              mv build/${doc}/${ROOTID}_color_en.pdf obs-landing/files/manuals/${doc}.pdf || exit 1
+            done
+      - name: Commit files
+        run: |
+          pushd obs-landing
+          git config --local user.email "bs-team@suse.de"
+          git config --local user.name "obs-docs-deployment"
+          git commit -m "Update books to current state" -a
+          git push


### PR DESCRIPTION
This GitHub action automatically builds the obs documentation and pushes the newly generated doc books to the obs-landing repository using a GitHub deployment key (basically an ssh key, that has only permission for a single repository).
It basically does the same that we did manually in the past https://github.com/openSUSE/obs-docu#update-documentation
See test runs on my fork https://github.com/krauselukas/obs-docu/actions/runs/1986616461

TODO:
- [x] Ignore files that do not influence the documentation itself, in order to prevent unnecessary commits on the obs-landing repository 