### PR TITLE
Document trigger_services step for SCM/CI Workflow Integration

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -381,11 +381,15 @@ rebuild_master:
           <listitem>
             <para>Set flags for projects, packages, repositories or architectures (set_flags)</para>
           </listitem>
+
+          <listitem>
+            <para>Trigger services of a package (trigger_services)</para>
+          </listitem>
         </itemizedlist>
 
         <warning>
           <para>The user the token belongs to needs to have permissions to
-          branch a package, link packages, configure repositories/architectures and rebuild packages.</para>
+          branch a package, link packages, configure repositories/architectures, rebuild packages and trigger services of a package.</para>
         </warning>
 
         <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.branch_a_package">
@@ -615,6 +619,25 @@ rebuild_master:
             package: ctris
             repository: openSUSE_Tumbleweed
             architecture: x86_64</screen>
+        </sect4>
+
+        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.trigger_services">
+          <title>Trigger Services of a Package</title>
+
+          <para>Given a project called <emphasis>home:Admin</emphasis> and a
+          package <emphasis>ctris</emphasis>, the step will trigger services of the
+          package <emphasis>home:Admin/ctris</emphasis>.</para>
+
+          <para>Be sure to have a <link xlink:href="https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.source_service.html">_service</link>
+          file in the package <emphasis>home:Admin/ctris</emphasis>.</para>
+
+          <para>This is an example of a configuration file with a trigger services step:</para>
+
+          <screen>workflow:
+  steps:
+    - trigger_services:
+        project: home:Admin
+        package: ctris</screen>
         </sect4>
       </sect3>
 


### PR DESCRIPTION
To test this locally:
1. Pull the changes from this PR, then run `daps2docker .`
2. Open the generated user guide in your favorite browser: `firefox /tmp/daps2docker-SXo2tVAc/obs-user-guide/html/book.obs-user/cha.obs.scm_ci_workflow_integration.html` (the string after `daps2-docker-` will be different).

Preview of the changes:
![preview-1](https://user-images.githubusercontent.com/1102934/161115779-c1b32b36-ec62-4c6c-971a-4e83193a26c7.png)
![preview-2](https://user-images.githubusercontent.com/1102934/161115787-37e6f9a1-e869-4043-8a45-8827d666b172.png)