### PR TITLE
Drop references to obsolete update_source service

### DIFF
--- a/xml/obs_ag_source_service.xml
+++ b/xml/obs_ag_source_service.xml
@@ -140,17 +140,12 @@
     &lt;param name="verifier"&gt;sha256&lt;/param&gt;
     &lt;param name="checksum"&gt;7f535a96a834b31ba2201a90c4d365990785dead92be02d4cf846713be938b78&lt;/param&gt;
   &lt;/service&gt;
-  &lt;service name="update_source" mode="disabled" /&gt;
 &lt;/services&gt;</screen>
    <para>
    This example downloads the files via download_files service via the given
    URLs from the spec file. When using osc this file gets committed as part of
    the commit. Afterwards the krabber-1.0.tar.gz file will always be compared
-   with the sha256 checksum. And last but not least there is the
-    <command>update_source</command> service mentioned, which is usually not
-   executed. Except when <command>osc service runall</command> is called,
-   which will try to upgrade the package to a newer source version available
-   online. </para>
+   with the sha256 checksum. </para>
  </sect2>
  <sect2>
   <title>Dropping a Source Service Again</title>

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -376,7 +376,6 @@
     &lt;param name="verifier"&gt;sha256&lt;/param&gt;
     &lt;param name="checksum"&gt;7f535a96a834b31ba2201a90c4d365990785dead92be02d4cf846713be938b78&lt;/param&gt;
   &lt;/service&gt;
-  &lt;service name="update_source" mode="disabled" /&gt;
 &lt;/services&gt;</screen>
   <para>
    With the example above, the services above are executed in the
@@ -394,13 +393,6 @@
     <para>
      Compares the downloaded file (<filename>krabber-1.0.tar.gz</filename>)
      against the SHA256 checksum.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     When <command>osc service runall</command> is run manually, update
-     the source archive from an online source. In all other cases, ignore
-     this part of the <filename>_service</filename> file.
     </para>
    </listitem>
   </orderedlist>


### PR DESCRIPTION
The update_source service is long obsolete and no package for this
service currently exists in openSUSE:Factory.