### PR TITLE
Add note about branches filter not supporting tag push events

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -834,7 +834,7 @@ workflow:
         source_project: games
         source_package: ctris
         target_project: home:jane_doe
-  filters: 
+  filters:
     event: pull_request</screen></para>
         </sect4>
 
@@ -863,6 +863,13 @@ workflow:
           <para>Learn more about <link
           linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.filters.delimiters">Filters
           Delimiters: only and ignore</link>.</para>
+
+          <note>
+            <para>
+              <emphasis role="bold">tag_push</emphasis> events are not supported by the
+              <emphasis role="bold">branches filter</emphasis>.
+            </para>
+          </note>
         </sect4>
       </sect3>
 
@@ -1222,7 +1229,7 @@ test_build:
         source_project: GNOME:Factory
         source_package: gnome-shell
         target_project: home:jane:playground
-  filters: 
+  filters:
     event: pull_request</screen>
 
         <para>Whenever someone opens a new pull request in the repository, OBS


### PR DESCRIPTION
![Screenshot 2023-02-15 at 15-37-42 SCM_CI Workflow Integration User Guide](https://user-images.githubusercontent.com/22001671/219058911-34e743b5-b806-4229-869f-601626be33d4.png)

Related to https://github.com/openSUSE/open-build-service/pull/13841