### PR TITLE
Remove commented XML that added inline image

### DIFF
--- a/xml/obs_best_practice_webui_usage.xml
+++ b/xml/obs_best_practice_webui_usage.xml
@@ -264,14 +264,6 @@ flood</screen>
   </figure>
   <note>
    <para> Published repositories are marked with the OBS truck</para> 
-    <!--<inlineequation>
-     <inlinemediaobject>
-      <imageobject>
-       <imagedata fileref="obs_lkw.png"/>
-      </imageobject>
-     </inlinemediaobject>
-    </inlineequation>-->
-   
   </note>
   <para>
    Now click <guimenu>Go to download repository</guimenu>. Note that publishing the


### PR DESCRIPTION
Follow-up  of #278

The image used in the commented XML was removed on a previous commit, as Daps considered it was not in use.
The XML has been commented on for 6 years now, it's safe to remove it.