### PR TITLE
Change the links to the new apidocs url

### DIFF
--- a/xml/obs_ag_tools.xml
+++ b/xml/obs_ag_tools.xml
@@ -282,7 +282,7 @@ Options:
     -X HTTP_METHOD, -m HTTP_METHOD, --method=HTTP_METHOD
                         specify HTTP method to use (GET|PUT|DELETE|POST)</screen>
    <para>The online API documentation is available at
-<link xlink:href="https://build.opensuse.org/apidocs"><emphasis>https://build.opensuse.org/apidocs</emphasis></link>
+<link xlink:href="https://api.opensuse.org/apidocs/"/>
    </para>
    <para>Some examples for admin stuff:</para>
 <screen># Read the global configuration file

--- a/xml/obs_binary_tracking.xml
+++ b/xml/obs_binary_tracking.xml
@@ -174,13 +174,13 @@
     <para>
      /search/released/binary/id : short form, just listing the matched
      binary identifiers. See the <link
-     xlink:href="https://build.opensuse.org/apidocs-new/index.html#/Search/get_search_released_binary_id">reference documentation</link>.
+     xlink:href="https://api.opensuse.org/apidocs/#/Search/get_search_released_binary_id">reference documentation</link>.
     </para>
    </listitem>
    <listitem>
     <para>/search/released/binary : long form, provides all other tracked
      information as described above. See the <link
-     xlink:href="https://build.opensuse.org/apidocs-new/index.html#/Search/get_search_released_binary">reference documentation</link>.
+     xlink:href="https://api.opensuse.org/apidocs/#/Search/get_search_released_binary">reference documentation</link>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/obs_notifications.xml
+++ b/xml/obs_notifications.xml
@@ -344,7 +344,7 @@
 &lt;/status&gt;
    </screen>
    <para>
-     For more informtion regarding the notifications API endpoints, check out our <link xlink:href="https://build.opensuse.org/apidocs-new/#/Notifications/get_my_notifications">New API Documentation</link>.
+     For more informtion regarding the notifications API endpoints, check out our <link xlink:href="https://api.opensuse.org/apidocs/#/Notifications/get_my_notifications">New API Documentation</link>.
    </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
Besides changing the urls to not point at `/apidocs-new` anymore, this also normalizes the links and switches them to api.opensuse.org domain. Merging this needs to wait until we switch the swagger apidocs to `/apidocs`