### PR TITLE
Add a link into a new chapter for the revamped API docs

### DIFF
--- a/xml/obs_glossary.xml
+++ b/xml/obs_glossary.xml
@@ -34,6 +34,20 @@
    </para>
   </glossdef>
  </glossentry>
+ <glossentry xml:id="obs.glos.apidoc">
+  <glossterm>API</glossterm>
+  <glossdef>
+   <para>
+    API stands for application programming interface. It let your product or service communicate with other products and services without having to know how they’re implemented.
+   </para>
+   <para>
+    The OBS API is located here: <link xlink:href="https://api.opensuse.org" />.
+   </para>
+   <para>
+    The documentation for the API is located here: <link xlink:href="https://api.opensuse.org/apidocs" />.
+   </para>
+  </glossdef>
+ </glossentry>
  <glossentry xml:id="obs.glos.appliance">
   <glossterm>Appliance</glossterm>
   <glossdef>

--- a/xml/obs_glossary.xml
+++ b/xml/obs_glossary.xml
@@ -38,7 +38,7 @@
   <glossterm>API</glossterm>
   <glossdef>
    <para>
-    API stands for application programming interface. It let your product or service communicate with other products and services without having to know how they’re implemented.
+    API stands for application programming interface. It lets your product or service communicate with other products and services without having to know how they’re implemented.
    </para>
    <para>
     The OBS API is located here: <link xlink:href="https://api.opensuse.org" />.


### PR DESCRIPTION
The Glossary lacks a term explaining what an API is, and while we're at it, add a link to our new API Docs site.

![image](https://github.com/openSUSE/obs-docu/assets/2650/7b381095-a8b5-4720-b9c1-bcc4247a0018)
