### PR TITLE
OBS caches download location is changed to `/var/tmp/oscbuild-packagecache`

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -61,7 +61,7 @@
 <!ENTITY osc            "osc">
 <!ENTITY osccmd         "<command xmlns='http://docbook.org/ns/docbook'>&osc;</command>">
 <!ENTITY oscbuildpath   "/var/tmp/oscbuild">
-<!ENTITY oscbuildcache  "/var/tmp/osbuild-packagecache">
+<!ENTITY oscbuildcache  "/var/tmp/oscbuild-packagecache">
 
 <!ENTITY gh             "GitHub">
 <!ENTITY gitorg         "obs-example">


### PR DESCRIPTION
## Fixes :- #299