### PR TITLE
Revert "Update entity-decl.ent"

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -61,7 +61,7 @@
 <!ENTITY osc            "osc">
 <!ENTITY osccmd         "<command xmlns='http://docbook.org/ns/docbook'>&osc;</command>">
 <!ENTITY oscbuildpath   "/var/tmp/oscbuild">
-<!ENTITY oscbuildcache  "/var/tmp/oscbuild-packagecache">
+<!ENTITY oscbuildcache  "/var/tmp/osbuild-packagecache">
 
 <!ENTITY gh             "GitHub">
 <!ENTITY gitorg         "obs-example">


### PR DESCRIPTION
This reverts commit d52e7e4bdf4226d4df2f04a35e2ad24e120d32da.

The default value was already correctly defined and used in the file `osc/conf.py` in the project `osc` project.