### PR TITLE
Location and minor change for Home Project link

### DIFF
--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -468,8 +468,8 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
    </step>
    <step>
     <para>
-     Click the <guimenu>Home Project</guimenu> link in the upper-right
-     corner.
+     Click the <guimenu>Your Home Project</guimenu> link in
+     the Places menu on the left.
     </para>
    </step>
    <step>


### PR DESCRIPTION
The description in the document no longer conforms to the current version of https://build.opensuse.org/ for the naming and location of the Home Project link.

It is now in a left menubar under Places and named Your Home Project.

I have validated the change with 

`daps2docker DC-obs-user-guide validate` and
`rm -rf /tmp/daps2docker-*; daps2docker DC-obs-user-guide html; xdg-open /tmp/daps2docker-*/obs-user-guide/html/book.obs-user/index.html`