### PR TITLE
DC-obs-user-guide: fix title so it refers to "User Guide"

### DIFF
--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -1,6 +1,6 @@
 ## ----------------------------
 ## Doc Config File for Open Build Service
-## Reference Guide
+## User Guide
 ## ----------------------------
 ##
 ## Basics


### PR DESCRIPTION
(Apparently, this used to be called the "Reference Guide", but that must have been a long time ago?)