### PR TITLE
user/obs_scm_ci_workflow_integration: gitea now supports token scopes

### DIFF
--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -89,7 +89,7 @@
           </listitem>
 
           <listitem>
-            <para>Gitea does not support scopes for access tokens</para>
+            <para>Gitea: repo</para>
           </listitem>
         </itemizedlist>
 


### PR DESCRIPTION
Fixes: https://github.com/openSUSE/obs-docu/issues/298