### PR TITLE
DC: migrate to the latest stylesheets

### DIFF
--- a/DC-obs-admin-guide
+++ b/DC-obs-admin-guide
@@ -15,7 +15,7 @@ PROFOS="opensuse;novell"
 PROFCONDITION="bogus"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
 ## Use DocBook5 instead of GeekoDoc

--- a/DC-obs-all
+++ b/DC-obs-all
@@ -13,7 +13,7 @@ PROFOS="opensuse;novell"
 PROFCONDITION="bogus"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
 ## Use DocBook5 instead of GeekoDoc

--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -15,7 +15,7 @@ PROFOS="opensuse;novell"
 PROFCONDITION="bogus"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
 ## Use DocBook5 instead of GeekoDoc


### PR DESCRIPTION
It came to my attention that we were using an obsolete set of stylesheets. Use the current version instead.