### PR TITLE
obs_build_config: refrain from nesting screen inside para

### DIFF
--- a/DC-obs-admin-guide
+++ b/DC-obs-admin-guide
@@ -18,5 +18,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
+## Use DocBook5 instead of GeekoDoc
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE

--- a/DC-obs-all
+++ b/DC-obs-all
@@ -16,5 +16,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
+## Use DocBook5 instead of GeekoDoc
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE

--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -18,5 +18,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
+## Use DocBook5 instead of GeekoDoc
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE

--- a/xml/obs_build_config.xml
+++ b/xml/obs_build_config.xml
@@ -973,18 +973,20 @@ Support: pax debbuild</screen>
   <para>
     An alternative way to enable caching based on build dependencies is to
     add "--enable-cache" as dependency, for example via a Substitute rule:
-    <screen><command>
-        Substitute: gcc-c++ gcc-c++ --enable-ccache
-    </command></screen>
+  </para>
+  <screen><command>
+      Substitute: gcc-c++ gcc-c++ --enable-ccache
+  </command></screen>
+  <para>
     This will always enable ccache when a direct build depdency to gcc-c++
     is required.
   </para>
   <para>
     It is also possible to set the type, eg:
-    <screen><command>
-        Substitute: cargo cargo --enable-ccache=sccache
-    </command></screen>
   </para>
+  <screen><command>
+      Substitute: cargo cargo --enable-ccache=sccache
+  </command></screen>
  </sect1>
 
  <sect1 xml:id="sec.prjconfig.macros">


### PR DESCRIPTION
Nesting screen inside para is a violation of the GeekoDoc XML schema and will cause the CI build to fail if/when we (eventually) switch to GeekoDoc.