### PR TITLE
SEO: rewrite certain xml:id values and validate against Geekodoc

### DIFF
--- a/DC-obs-admin-guide
+++ b/DC-obs-admin-guide
@@ -18,8 +18,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-## Use DocBook5 instead of GeekoDoc
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+### Use DocBook5 instead of GeekoDoc
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
 
 ## Disabled SUSE logo
 XSLTPARAM="--param generate.logo=0"

--- a/DC-obs-admin-guide
+++ b/DC-obs-admin-guide
@@ -6,7 +6,7 @@
 ## Basics
 MAIN="MAIN-obs.xml"
 # See "book-obs-admin-guide.xml"
-ROOTID="book.obs-admin"
+ROOTID="book-obs-admin"
 
 ## Profiling
 PROFOS="opensuse;novell"
@@ -18,8 +18,9 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-### Use DocBook5 instead of GeekoDoc
+### Use GeekoDoc
 #DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
 
 ## Disabled SUSE logo
 XSLTPARAM="--param generate.logo=0"

--- a/DC-obs-all
+++ b/DC-obs-all
@@ -16,8 +16,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-## Use DocBook5 instead of GeekoDoc
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+### Use DocBook5 instead of GeekoDoc
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
 
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE

--- a/DC-obs-all
+++ b/DC-obs-all
@@ -16,8 +16,9 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-### Use DocBook5 instead of GeekoDoc
+### Use GeekoDoc
 #DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
 
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE

--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -18,8 +18,8 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-## Use DocBook5 instead of GeekoDoc
-DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+### Use DocBook5 instead of GeekoDoc
+#DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
 
 ## Disabled SUSE logo
 XSLTPARAM="--param generate.logo=0"

--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -6,7 +6,7 @@
 ## Basics
 MAIN="MAIN-obs.xml"
 # See "book-obs-user-guide.xml"
-ROOTID="book.obs-user"
+ROOTID="book-obs-user"
 
 ## Profiling
 PROFOS="opensuse;novell"
@@ -18,8 +18,9 @@ PROFCONDITION="bogus"
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse"
 
-### Use DocBook5 instead of GeekoDoc
+### Use GeekoDoc
 #DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
 
 ## Disabled SUSE logo
 XSLTPARAM="--param generate.logo=0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ daps2docker DC-obs-user-guide validate
 or if you want to preview the HTML files you can use
 
 ```
-rm -rf /tmp/daps2docker-*; daps2docker DC-obs-user-guide html; xdg-open /tmp/daps2docker-*/obs-user-guide/html/book.obs-user/index.html
+rm -rf /tmp/daps2docker-*; daps2docker DC-obs-user-guide html; xdg-open /tmp/daps2docker-*/obs-user-guide/html/book-obs-user/index.html
 ```
 
 For more detailed information see

--- a/xml/MAIN-obs.xml
+++ b/xml/MAIN-obs.xml
@@ -7,7 +7,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
 ]>
-<set version="5.1" xml:lang="en" xml:id="art_obs_quickstart"
+<set version="5.1" xml:lang="en" xml:id="art-obs-quickstart"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:dm="urn:x-suse:ns:docmanager"
   xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -23,7 +23,7 @@
   </dm:docmanager>
  </info>
 <!--
-  <book xml:id="book.obs.techpaper">
+  <book xml:id="book-obs-techpaper">
    <title>Technical Papers</title>
    <info/>
   </book>

--- a/xml/MAIN-obs.xml
+++ b/xml/MAIN-obs.xml
@@ -22,12 +22,6 @@
    </dm:bugtracker>
   </dm:docmanager>
  </info>
-<!--
-  <book xml:id="book-obs-techpaper">
-   <title>Technical Papers</title>
-   <info/>
-  </book>
--->
   <xi:include href="book-obs-user-guide.xml"/>
   <xi:include href="book-obs-admin-guide.xml"/>
 </set>

--- a/xml/MAIN-obs.xml
+++ b/xml/MAIN-obs.xml
@@ -7,7 +7,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
 ]>
-<set version="5.1" xml:lang="en" xml:id="art-obs-quickstart"
+<set version="5.1" xml:lang="en"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:dm="urn:x-suse:ns:docmanager"
   xmlns:xi="http://www.w3.org/2001/XInclude"

--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -14,7 +14,7 @@ https://www.suse.com/communities/blog/open-build-service-create-image-template/
 https://www.suse.com/communities/blog/suse-studio-integration/
 -->
 
-<chapter version="5.1" xml:lang="en" xml:id="art.obs.bg"
+<chapter version="5.1" xml:lang="en" xml:id="art-obs-bg"
  xmlns="http://docbook.org/ns/docbook" xmlns:dm="urn:x-suse:ns:docmanager"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -31,7 +31,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   </abstract>
  </info>
 
- <sect1 xml:id="sec.obsbg.targetaudience">
+ <sect1 xml:id="sec-obsbg-targetaudience">
   <title>Target Audience</title>
   <para>
    This document is intended for users and developers interested in
@@ -42,7 +42,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   <remark>toms 2017-08-03: Add some links to basic tutorials etc.?</remark>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.concept">
+ <sect1 xml:id="sec-obsbg-concept">
   <title>Conceptual Overview</title>
   <para>
    Created in 2005, the &obs; (&obsa;) is a generic system for building and
@@ -53,7 +53,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
    (&suse;, Debian, Ubuntu, Red Hat, Windows, etc.) and hardware architectures
    (&x86;, &amd64;, &zseries;, &ppc; etc.).
   </para>
-  <sect2 xml:id="sec.obsbg.concept.pkgspec">
+  <sect2 xml:id="sec-obsbg-concept-pkgspec">
    <title>Build Recipe</title>
    <para>
     To create a package in &obsa;, you need a <firstterm>build recipe</firstterm>
@@ -106,7 +106,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
      class="extension">.spec</filename>.
    </para>
   </sect2>
-  <sect2 xml:id="sec.obsbg.buildhost">
+  <sect2 xml:id="sec-obsbg-buildhost">
    <title>Build Hosts and Packages</title>
   <para>
    The &obsa; server provides a Web interface and an API. The API is
@@ -139,10 +139,10 @@ https://www.suse.com/communities/blog/suse-studio-integration/
    scope of this guide.
   </para>
   <para>
-   The schematic in <xref linkend="fig.obsbg.concept"/> shows the components
+   The schematic in <xref linkend="fig-obsbg-concept"/> shows the components
    in context.
   </para>
-  <figure xml:id="fig.obsbg.concept">
+  <figure xml:id="fig-obsbg-concept">
    <title>Conceptual Overview of &obs;</title>
    <mediaobject>
     <imageobject>
@@ -151,7 +151,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
    </mediaobject>
   </figure>
   </sect2>
-  <sect2 xml:id="sec.obsbg.project">
+  <sect2 xml:id="sec-obsbg-project">
    <title>Projects and Packages</title>
    <para>
     In &obsa;, packages are organized in <emphasis>projects</emphasis>.
@@ -192,14 +192,14 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   </sect2>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.req">
+ <sect1 xml:id="sec-obsbg-req">
   <title>Requirements for Working with the &osccmd; Command-Line Tool</title>
   <para>
    Before you start working with &obs;, make sure that the following
    requirements are met.
   </para>
   <variablelist>
-   <varlistentry xml:id="vle.obsbg.req.software">
+   <varlistentry xml:id="vle-obsbg-req-software">
     <term>Software Requirements</term>
     <listitem>
      <para>
@@ -249,7 +249,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   </variablelist>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.usagescenarios">
+ <sect1 xml:id="sec-obsbg-usagescenarios">
   <title>Covered Scenarios</title>
   <para>
    This guide is based on the following assumptions.
@@ -276,7 +276,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
    </listitem>
    <listitem>
     <para>You are using a customized system as shown in <xref
-     linkend="sec.obsbg.obsconfig"/>.</para>
+     linkend="sec-obsbg-obsconfig"/>.</para>
    </listitem>
   </itemizedlist>
   <para>All examples use the following elements.</para>
@@ -312,7 +312,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   </para>
   <variablelist>
    <varlistentry>
-    <term><xref linkend="sec.obsbg.uc.setuphome"/></term>
+    <term><xref linkend="sec-obsbg-uc-setuphome"/></term>
     <listitem>
      <para>
       Setting up a home project using the &obsa; Web UI.
@@ -320,7 +320,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><xref linkend="sec.obsbg.uc.newprj"/></term>
+    <term><xref linkend="sec-obsbg-uc-newprj"/></term>
     <listitem>
      <para>
       Creating packages from a basic project hosted on &gh;.
@@ -328,7 +328,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><xref linkend="sec.obsbg.uc.patching"/></term>
+    <term><xref linkend="sec-obsbg-uc-patching"/></term>
     <listitem>
      <para>
       Patching source code without touching the original
@@ -337,7 +337,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><xref linkend="sec.obsbg.uc.branchprj"/></term>
+    <term><xref linkend="sec-obsbg-uc-branchprj"/></term>
     <listitem>
      <para>
       Branching a project, making changes, and submitting back
@@ -357,7 +357,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   </variablelist>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.obsconfig">
+ <sect1 xml:id="sec-obsbg-obsconfig">
   <title>Configuring Your System for &obsa;</title>
   <para>
    While it is possible to use the &osccmd; tool without any
@@ -376,7 +376,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
   <para>
    Follow the steps below to customize <command>sudo</command>.
   </para>
-  <procedure xml:id="pro.obsbg.obsconfig">
+  <procedure xml:id="pro-obsbg-obsconfig">
    <title>Configuring <command>sudo</command></title>
    <para>
      To allow all users in the
@@ -389,7 +389,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
        This group will contain all users which are allowed to build packages: </para>
       <screen>&prompt.root;<command>groupadd</command> osc</screen>
      </step>
-     <step xml:id="st.oscbg.usermod">
+     <step xml:id="st-oscbg-usermod">
       <para>Add users to your newly created group <systemitem class="groupname"
         >osc</systemitem> which are allowed to build packages:
       </para>
@@ -443,7 +443,7 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
   </note>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.uc.setuphome">
+ <sect1 xml:id="sec-obsbg-uc-setuphome">
   <title>Setting Up Your Home Project for the First Time</title>
   <para>
    This section shows how to set up your home project after
@@ -459,7 +459,7 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
    specific package.
   </para>
   <para>Setting up a home project is done as shown below.</para>
-  <procedure xml:id="pro.obsbg.uc.setuphome.addrepo">
+  <procedure xml:id="pro-obsbg-uc-setuphome-addrepo">
    <title>Adding Global Build Targets to Your Home Project</title>
    <step>
     <para>
@@ -512,7 +512,7 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
   <remark>toms 2017-08-14: Maybe add a screenshot of the Web UI?</remark>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.uc.newprj">
+ <sect1 xml:id="sec-obsbg-uc-newprj">
   <title>Creating a New Project</title>
   <para>
    This section demonstrates how to create packages from a simple C++ project
@@ -545,9 +545,9 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
   <para>
    To create a package from the upstream project, follow the steps below.
   </para>
-  <procedure xml:id="pro.obsbg.uc.basicprj">
+  <procedure xml:id="pro-obsbg-uc-basicprj">
    <step>
-    <para>Set up your project as shown in <xref linkend="sec.obsbg.uc.setuphome"/>.
+    <para>Set up your project as shown in <xref linkend="sec-obsbg-uc-setuphome"/>.
     </para>
    </step>
    <step>
@@ -600,32 +600,32 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
       baseform="Spec File">spec file</firstterm>.
      The skeleton of such a spec file looks like this:
     </para>
-    <example xml:id="ex.obsbg.uc.basicprj.skeletonspec">
+    <example xml:id="ex-obsbg-uc-basicprj-skeletonspec">
      <title>Skeleton of a Spec File</title>
     <screen>#
 # spec file for package &gitproject;
 #
 # -- Copyright omitted --
 
-Name:           &gitproject; <co xml:id="co.obsbg.uc.basicprj.metadata"/>
-Version:        &gitprjvers; <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-Release:        0 <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-License:        GPL-3.0 <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-Group:          Documentation <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-Summary:        Frobnication Tool <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-Url:            &gitupstream1; <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-Source:         &gitproject;-%{version}.tar.gz <xref linkend="co.obsbg.uc.basicprj.metadata"/>
-BuildRequires:  gcc <co xml:id="co.obsbg.uc.basicprj.buildreq"/>
-BuildRequires:  cmake <xref linkend="co.obsbg.uc.basicprj.buildreq"/>
+Name:           &gitproject; <co xml:id="co-obsbg-uc-basicprj-metadata"/>
+Version:        &gitprjvers; <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Release:        0 <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+License:        GPL-3.0 <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Group:          Documentation <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Summary:        Frobnication Tool <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Url:            &gitupstream1; <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Source:         &gitproject;-%{version}.tar.gz <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+BuildRequires:  gcc <co xml:id="co-obsbg-uc-basicprj-buildreq"/>
+BuildRequires:  cmake <xref linkend="co-obsbg-uc-basicprj-buildreq"/>
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
-%description <co xml:id="co.obsbg.uc.basicprj.description"/>
+%description <co xml:id="co-obsbg-uc-basicprj-description"/>
 This tool frobnicates the bar with the foo when choosing the baz.
 
-%prep <co xml:id="co.obsbg.uc.basicprj.prep"/>
+%prep <co xml:id="co-obsbg-uc-basicprj-prep"/>
 %setup -q -n %{name}-%{version}
 
-%build <co xml:id="co.obsbg.uc.basicprj.build"/><!--
+%build <co xml:id="co-obsbg-uc-basicprj-build"/><!--
 export CFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
 export CXXFLAGS="$RPM_OPT_FLAGS -DNDEBUG"
 
@@ -636,17 +636,17 @@ cmake . \
 make
 -->
 
-%install <co xml:id="co.obsbg.uc.basicprj.install"/><!--
+%install <co xml:id="co-obsbg-uc-basicprj-install"/><!--
 make install DESTDIR="$RPM_BUILD_ROOT"-->
 
-%files <co xml:id="co.obsbg.uc.basicprj.files"/>
+%files <co xml:id="co-obsbg-uc-basicprj-files"/>
 %defattr(-,root,root,-)
 %doc README LICENSE *.txt
 %{_bindir}/*
 
-%changelog <co xml:id="co.obsbg.uc.basicprj.cl"/></screen>
+%changelog <co xml:id="co-obsbg-uc-basicprj-cl"/></screen>
     <calloutlist>
-     <callout arearefs="co.obsbg.uc.basicprj.metadata">
+     <callout arearefs="co-obsbg-uc-basicprj-metadata">
       <formalpara>
        <title>The Header</title>
        <para>Metadata like package name, version, release,
@@ -655,7 +655,7 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
        </para>
       </formalpara>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.buildreq">
+     <callout arearefs="co-obsbg-uc-basicprj-buildreq">
       <formalpara>
        <title>Build Requirements</title>
        <para>Lists package dependencies that are required for building.
@@ -665,25 +665,25 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
       <para>
       </para>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.description">
+     <callout arearefs="co-obsbg-uc-basicprj-description">
       <formalpara>
        <title>The Description Section</title>
        <para>Describes the purpose of the package and gives a comprehensive
         explanation.</para>
       </formalpara>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.prep">
+     <callout arearefs="co-obsbg-uc-basicprj-prep">
       <formalpara>
        <title>The Preparation Section</title>
        <para>
         Prepares the sources for building. This usually includes unpacking
         them with the <literal>%setup</literal> macro and patching them using
         the <literal>%patch</literal> macro. (For more information about patching, see
-        <xref linkend="sec.obsbg.uc.patching"/>.)
+        <xref linkend="sec-obsbg-uc-patching"/>.)
        </para>
       </formalpara>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.build">
+     <callout arearefs="co-obsbg-uc-basicprj-build">
       <formalpara>
        <title>The Build Section</title>
        <para>
@@ -693,7 +693,7 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
       <para>
       </para>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.install">
+     <callout arearefs="co-obsbg-uc-basicprj-install">
       <formalpara>
        <title>The Install Section</title>
        <para>Contains commands or RPM macros which
@@ -701,7 +701,7 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
        </para>
       </formalpara>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.files">
+     <callout arearefs="co-obsbg-uc-basicprj-files">
       <formalpara>
        <title>The Files Section</title>
        <para>Lists all files and directories which belong to
@@ -711,7 +711,7 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
        </para>
       </formalpara>
      </callout>
-     <callout arearefs="co.obsbg.uc.basicprj.cl">
+     <callout arearefs="co-obsbg-uc-basicprj-cl">
       <formalpara>
        <title>The Changelog Section</title>
        <para>This section is usually empty. Instead, &obsa; searches for a
@@ -794,11 +794,11 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
   <screen>&prompt.user;<command>osc</command> buildlog openSUSE_Tumbleweed x86_64</screen>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.uc.patching">
+ <sect1 xml:id="sec-obsbg-uc-patching">
   <title>Patching Source Code</title>
   <para>
    This section describes how to patch an upstream project. We use the same
-   project as shown in <xref linkend="sec.obsbg.uc.newprj"/>.
+   project as shown in <xref linkend="sec-obsbg-uc-newprj"/>.
   </para>
   <para>
    There are different reasons for patching a package.
@@ -854,7 +854,7 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
   </itemizedlist>
   <para>
    We assume that you already have a project as described in
-  <xref linkend="sec.obsbg.uc.newprj"/>. The project directory should look
+  <xref linkend="sec-obsbg-uc-newprj"/>. The project directory should look
    similar to this:
   </para>
   <screen><emphasis>project directory</emphasis>
@@ -974,7 +974,7 @@ Patch0:         &gitproject;_main.diff</screen>
   </para>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.uc.branchprj">
+ <sect1 xml:id="sec-obsbg-uc-branchprj">
   <title>Branching a Package</title>
   <para>
    This section describes how to collaborate between projects.
@@ -1017,7 +1017,7 @@ Patch0:         &gitproject;_main.diff</screen>
    User <systemitem class="username">&obsuser2;</systemitem> has to perform the
    following steps:
   </para>
-  <procedure xml:id="pro.obsbg.uc.branchprj">
+  <procedure xml:id="pro-obsbg-uc-branchprj">
    <title>Branching from a Project</title>
    <step>
     <para>
@@ -1039,7 +1039,7 @@ Patch0:         &gitproject;_main.diff</screen>
    </step>
    <step>
     <para>Make changes as shown in <xref
-     linkend="sec.obsbg.uc.patching"/>.
+     linkend="sec-obsbg-uc-patching"/>.
     </para>
    </step>
    <step>
@@ -1156,7 +1156,7 @@ Patch0:         &gitproject;_main.diff</screen>
   <note>
     <para>If preferred, the below steps can also be performed using the OBS GUI. Requests can be managed under the <guimenu>Tasks</guimenu> tab.</para>
   </note>
-  <procedure xml:id="pro.obsbg.uc.branchprj.sr">
+  <procedure xml:id="pro-obsbg-uc-branchprj-sr">
    <title>Dealing with Submit Requests</title>
    <step>
     <para>Show all submit requests that belong to your home project</para>
@@ -1240,20 +1240,20 @@ Patch0:         &gitproject;_main.diff</screen>
     <para>
      When prompted, accept the GPG key of the download repository.</para>
    </step>
-   <step xml:id="st.obsbg.install">
+   <step xml:id="st-obsbg-install">
     <para>Install the package:</para>
     <screen>&prompt.root;<command>zypper</command> install &gitproject;</screen>
    </step>
   </procedure>
   <para>
-   To update the package again, run <xref linkend="st.obsbg.install"/>.
+   To update the package again, run <xref linkend="st-obsbg-install"/>.
    You do not need to execute
    <xref linkend="st.obsbg.uc.install-from-obs.repourls"/>, as the
    repository is already configured in your system.
   </para>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.cheatsheet">
+ <sect1 xml:id="sec-obsbg-cheatsheet">
   <title>Other Useful &osccmd; Commands</title>
   <para>
    The following list gives you a short overview of frequently used &osccmd;

--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -571,12 +571,12 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
       baseform="Working Directory">working directory</firstterm>:
     </para>
     <screen>&prompt.user;<command>cd</command> &obsworkdir1;
-&prompt.user;<command>osc</command> mkpac &gitproject;</screen>
+&prompt.user;<command>osc</command> mkpac &sampleprj;</screen>
    </step>
    <step>
     <para>
      Get the source code of the upstream project and save it in
-     <filename>&obsworkdir1;/&gitproject;</filename>.
+     <filename>&obsworkdir1;/&sampleprj;</filename>.
     </para>
     <para>
      Download a TAR archive of the sources. You do not have to unpack it yet.
@@ -603,18 +603,18 @@ Cmnd_Alias  OSC_CMD = /usr/bin/osc, /usr/bin/build
     <example xml:id="ex-obsbg-uc-basicprj-skeletonspec">
      <title>Skeleton of a Spec File</title>
     <screen>#
-# spec file for package &gitproject;
+# spec file for package &sampleprj;
 #
 # -- Copyright omitted --
 
-Name:           &gitproject; <co xml:id="co-obsbg-uc-basicprj-metadata"/>
-Version:        &gitprjvers; <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Name:           &sampleprj; <co xml:id="co-obsbg-uc-basicprj-metadata"/>
+Version:        &prjvers; <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 Release:        0 <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 License:        GPL-3.0 <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 Group:          Documentation <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 Summary:        Frobnication Tool <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 Url:            &gitupstream1; <xref linkend="co-obsbg-uc-basicprj-metadata"/>
-Source:         &gitproject;-%{version}.tar.gz <xref linkend="co-obsbg-uc-basicprj-metadata"/>
+Source:         &sampleprj;-%{version}.tar.gz <xref linkend="co-obsbg-uc-basicprj-metadata"/>
 BuildRequires:  gcc <co xml:id="co-obsbg-uc-basicprj-buildreq"/>
 BuildRequires:  cmake <xref linkend="co-obsbg-uc-basicprj-buildreq"/>
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -725,7 +725,6 @@ make install DESTDIR="$RPM_BUILD_ROOT"-->
     </calloutlist>
     </example>
     <para>
-     <remark>toms 2017-08-17: FIXME: Better link to OBS instead of GH?</remark>
      For the complete spec file, see <link xlink:href="&referencespec;"/>.
     </para>
    </step>
@@ -744,13 +743,13 @@ Fri Aug 23 12:31:41 UTC 2017 - &exampleuser_mail;</screen>
     </para>
     <para>
      Save the file and leave the editor. &osccmd; then
-     creates the file <filename>&gitproject;.changes</filename>.
+     creates the file <filename>&sampleprj;.changes</filename>.
     </para>
     <para>Your project directory should now look something like this:</para>
     <screen><emphasis>project directory</emphasis>
-     ├── &gitproject;-&gitprjvers;.tar.gz
-     ├── &gitproject;.changes
-     └── &gitproject;.spec</screen>
+     ├── &sampleprj;-&prjvers;.tar.gz
+     ├── &sampleprj;.changes
+     └── &sampleprj;.spec</screen>
    </step>
    <step>
     <para>Add all the files to your working directory:</para>
@@ -858,9 +857,9 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
    similar to this:
   </para>
   <screen><emphasis>project directory</emphasis>
-├── &gitproject;-&gitprjvers;.tar.gz
-├── &gitproject;.changes
-└── &gitproject;.spec</screen>
+├── &sampleprj;-&prjvers;.tar.gz
+├── &sampleprj;.changes
+└── &sampleprj;.spec</screen>
   <para>In our case, we want to modify the source code under
    <filename>src/main.cpp</filename> to change the greeting message.
   </para>
@@ -874,21 +873,21 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
     <substeps>
      <step>
       <para>Unpack the source code:</para>
-      <screen>&prompt.user;<command>tar</command> xvf &gitproject;-*.tar.gz</screen>
+      <screen>&prompt.user;<command>tar</command> xvf &sampleprj;-*.tar.gz</screen>
       <para>
        If you have downloaded the archive from &gh;, the archive contains
        a directory in the form <filename><replaceable
         >NAME</replaceable>-<replaceable>VERSION</replaceable></filename>.
        In our case, unpacking the downloaded archive results in the
-       <filename>&gitproject;-&gitprjvers;/</filename> directory.
+       <filename>&sampleprj;-&prjvers;/</filename> directory.
       </para>
      </step>
      <step>
       <para>
-       Switch to the directory <filename>&gitproject;-&gitprjvers;/</filename>
+       Switch to the directory <filename>&sampleprj;-&prjvers;/</filename>
        and make a copy of the original C++ source file:
       </para>
-      <screen>&prompt.user;<command>cd</command> &gitproject;-&gitprjvers;/
+      <screen>&prompt.user;<command>cd</command> &sampleprj;-&prjvers;/
 &prompt.user;<command>cp</command> src/main.cpp src/main.cpp.orig</screen>
      </step>
      <step>
@@ -913,7 +912,7 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
      <step>
       <para>Redirect the diff into a file:</para>
       <screen>&prompt.user;<command>diff</command> -u src/main.cpp.orig src/main.cpp \
-  > ../&gitproject;_main.diff</screen>
+  > ../&sampleprj;_main.diff</screen>
       <para>
        You can use an arbitrary name for the patch file. However, we
        recommend giving the file a descriptive name and adding the name of the
@@ -927,7 +926,7 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
      <step>
       <para>
        You can now remove the directory <filename
-        >&gitproject;-&gitprjvers;/</filename>, as it is not needed anymore.
+        >&sampleprj;-&prjvers;/</filename>, as it is not needed anymore.
       </para>
      </step>
     </substeps>
@@ -935,8 +934,8 @@ openSUSE_Tumbleweed x86_64 *.spec--></screen>
    <step>
     <para>Open your spec file and add the following line in the header under
     the <literal>Source</literal> line like this:</para>
-    <screen>Source:         &gitproject;-%{version}.tar.gz
-Patch0:         &gitproject;_main.diff</screen>
+    <screen>Source:         &sampleprj;-%{version}.tar.gz
+Patch0:         &sampleprj;_main.diff</screen>
    </step>
    <step>
     <para>In the <literal>%prep</literal> section, add the <literal>%patch</literal>
@@ -949,7 +948,7 @@ Patch0:         &gitproject;_main.diff</screen>
     <para>
      Add your patch file to the local repository:
     </para>
-    <screen>&prompt.user;<command>osc</command> add &gitproject;_main.diff
+    <screen>&prompt.user;<command>osc</command> add &sampleprj;_main.diff
 </screen>
    </step>
    <step>
@@ -1009,7 +1008,7 @@ Patch0:         &gitproject;_main.diff</screen>
   </itemizedlist>
   <para>
    Let us assume that there is a user <systemitem class="username">&obsuser1;</systemitem>
-   who has created a package <uri>&obshome1;/&gitproject;</uri>
+   who has created a package <uri>&obshome1;/&sampleprj;</uri>
    on &obsa;. Now, a second user, <systemitem class="username">&obsuser2;</systemitem>,
    would like to submit a code change request to that package.
   </para>
@@ -1027,15 +1026,15 @@ Patch0:         &gitproject;_main.diff</screen>
    </step>
    <step>
     <para>Create a branch from &exampleuser_plain;'s home project:</para>
-    <screen>&prompt.user2;<command>osc</command> branchco &obshome1; &gitproject;</screen>
-    <para>This creates a branched package in &obsa; at <uri>&obsbranch2;/&gitproject;</uri>
+    <screen>&prompt.user2;<command>osc</command> branchco &obshome1; &sampleprj;</screen>
+    <para>This creates a branched package in &obsa; at <uri>&obsbranch2;/&sampleprj;</uri>
      and checks out a directory
-     <filename>&obsworkdir2;:branches:home:&obsuser1;:&gitproject;</filename>.
+     <filename>&obsworkdir2;:branches:home:&obsuser1;:&sampleprj;</filename>.
     </para>
    </step>
    <step>
     <para>Change the working directory to your checked-out branch:</para>
-    <screen>&prompt.user2;<command>cd</command> &obsworkdir2;/branches/home/&obsuser1;/&gitproject;</screen>
+    <screen>&prompt.user2;<command>cd</command> &obsworkdir2;/branches/home/&obsuser1;/&sampleprj;</screen>
    </step>
    <step>
     <para>Make changes as shown in <xref
@@ -1087,7 +1086,7 @@ Patch0:         &gitproject;_main.diff</screen>
      be submitted together. To avoid that, specify the names of the source and
      destination projects and the package name:
     </para>
-    <screen>&prompt.user2;<command>osc</command> submitreq &obsbranch2;:&obshome1; &gitproject; &obshome1;</screen>
+    <screen>&prompt.user2;<command>osc</command> submitreq &obsbranch2;:&obshome1; &sampleprj; &obshome1;</screen>
    </step>
   </procedure>
   <para>
@@ -1219,7 +1218,7 @@ Patch0:         &gitproject;_main.diff</screen>
    <uri>&obsdnlurlhome1;/openSUSE_Tumbleweed</uri>. This <emphasis>download
    repository</emphasis> is used as an installation source for Zypper or &yast;.
   </para>
-  <para>To install the <package>&gitproject;</package> package from your home project,
+  <para>To install the <package>&sampleprj;</package> package from your home project,
   use the following steps:</para>
   <procedure>
    <step xml:id="st.obsbg.uc.install-from-obs.repourls">
@@ -1242,7 +1241,7 @@ Patch0:         &gitproject;_main.diff</screen>
    </step>
    <step xml:id="st-obsbg-install">
     <para>Install the package:</para>
-    <screen>&prompt.root;<command>zypper</command> install &gitproject;</screen>
+    <screen>&prompt.root;<command>zypper</command> install &sampleprj;</screen>
    </step>
   </procedure>
   <para>

--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -346,7 +346,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><xref linkend="sec.obsbg.uc.install-from-obs"/></term>
+    <term><xref linkend="sec-obsbg-uc-install-from-obs"/></term>
     <listitem>
      <para>
       Integrating the download repository into your system
@@ -1196,7 +1196,7 @@ Patch0:         &sampleprj;_main.diff</screen>
   </para>
  </sect1>
 
- <sect1 xml:id="sec.obsbg.uc.install-from-obs">
+ <sect1 xml:id="sec-obsbg-uc-install-from-obs">
   <title>Installing Packages from &obsa;</title>
   <para>
    &obsa; provides a place containing all the distribution-specific and
@@ -1221,7 +1221,7 @@ Patch0:         &sampleprj;_main.diff</screen>
   <para>To install the <package>&sampleprj;</package> package from your home project,
   use the following steps:</para>
   <procedure>
-   <step xml:id="st.obsbg.uc.install-from-obs.repourls">
+   <step xml:id="st-obsbg-uc-install-from-obs-repourls">
     <para>Inside your working directory, determine the download repository
      URLs:</para>
     <screen>&prompt.user;<command>osc</command> repourls
@@ -1232,7 +1232,7 @@ Patch0:         &sampleprj;_main.diff</screen>
     <para>Copy the desired URL of your preferred distribution. In our case, that
      is the line containing <systemitem>openSUSE_Tumbleweed</systemitem>.</para>
    </step>
-   <step xml:id="st.obsbg.uc.install-from-obs.zypperar">
+   <step xml:id="st-obsbg-uc-install-from-obs-zypperar">
     <para>Use <command>zypper</command> and add the copied URL:
     </para>
     <screen>&prompt.root;<command>zypper</command> addrepo &obsdnlurlhome1;/openSUSE_Tumbleweed/&obshome1;.repo</screen>
@@ -1247,7 +1247,7 @@ Patch0:         &sampleprj;_main.diff</screen>
   <para>
    To update the package again, run <xref linkend="st-obsbg-install"/>.
    You do not need to execute
-   <xref linkend="st.obsbg.uc.install-from-obs.repourls"/>, as the
+   <xref linkend="st-obsbg-uc-install-from-obs-repourls"/>, as the
    repository is already configured in your system.
   </para>
  </sect1>

--- a/xml/book-obs-admin-guide.xml
+++ b/xml/book-obs-admin-guide.xml
@@ -10,7 +10,7 @@
 <book xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:lang="en"
- xml:id="book.obs-admin">
+ xml:id="book-obs-admin">
  <title>Administrator Guide</title>
  <subtitle>&productname;</subtitle>
  <info>

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -44,11 +44,11 @@
     see https://en.opensuse.org/openSUSE:Build_Service_Tutorial
   * Use CI services
 -->
- <part xml:id="par.first_steps">
+ <part xml:id="par-first-steps">
   <title>First Steps</title>
   <xi:include href="art-obs-beginners-guide.xml"/>
  </part>
- <part xml:id="par.concepts">
+ <part xml:id="par-concepts">
   <title>Concepts</title>
 <!--  <xi:include href="obs_user_concept.xml"/>-->
   <xi:include href="obs_package_formats.xml"/>
@@ -60,7 +60,7 @@
   <xi:include href="obs_build_config.xml"/>
  </part>
 
- <part xml:id="par.working">
+ <part xml:id="par-working">
   <title>Usage</title>
   <xi:include href="obs_basic_workflow.xml"/>
   <xi:include href="osc_building.xml"/>
@@ -79,7 +79,7 @@
   <xi:include href="obs_product_building.xml"/>
  </part>
 
- <part xml:id="par.best_practices">
+ <part xml:id="par-best-practices">
   <title>Best Practices</title>
   <xi:include href="obs_best_practice_webui_usage.xml"/>
   <xi:include href="obs_best_practice_basics.xml"/>
@@ -92,7 +92,7 @@
   <xi:include href="obs_best_practice_howto.xml"/>
  </part>
 
- <part xml:id="par.reference">
+ <part xml:id="par-reference">
   <title>Reference</title>
  <!--<xi:include href="obs_motivation.xml"/>-->
  <!-- basic parts -->

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -63,7 +63,7 @@
  <part xml:id="par-working">
   <title>Usage</title>
   <xi:include href="obs_basic_workflow.xml"/>
-  <xi:include href="osc_building.xml"/>
+  <xi:include href="obs_local_building.xml"/>
 
   <xi:include href="obs_source_services.xml"/>
   <!-- tbd: <xi:include href="obs_signing.xml"/>-->

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -7,7 +7,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<book version="5.1" xml:lang="en" xml:id="book.obs-user"
+<book version="5.1" xml:lang="en" xml:id="book-obs-user"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -65,7 +65,7 @@
   <xi:include href="obs_basic_workflow.xml"/>
   <xi:include href="osc_building.xml"/>
 
-  <xi:include href="obs_source_service.xml"/>
+  <xi:include href="obs_source_services.xml"/>
   <!-- tbd: <xi:include href="obs_signing.xml"/>-->
 
   <xi:include href="obs_scm_ci_workflow_integration.xml" />
@@ -108,7 +108,6 @@
  <xi:include href="obs_image_templates.xml"/>
 <!-- <xi:include href="obs_build_config.xml"/>-->
  <!-- advanced parts -->
-<!-- <xi:include href="obs_source_service.xml"/>-->
  <xi:include href="obs_multibuild.xml"/>
 <!-- <xi:include href="obs_signing.xml"/>-->
  <!--<xi:include href="obs_product_building.xml"/>-->

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -13,7 +13,7 @@
  <para>The following documentation is available for &obsa;:</para>
  <variablelist>
   <varlistentry>
-   <term><xref linkend="book.obs-admin"/></term>
+   <term><xref linkend="book-obs-admin"/></term>
    <listitem>
     <para>
      This guide offers information about the initial setup and maintenance
@@ -22,7 +22,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><xref linkend="book.obs-user"/></term>
+   <term><xref linkend="book-obs-user"/></term>
    <listitem>
     <para>
      This guide is intended for users of &obs;. The first part describes basic

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -65,10 +65,10 @@
 
 <!ENTITY gh             "GitHub">
 <!ENTITY gitorg         "obs-example">
-<!ENTITY gitproject     "my-first-obs-package">
-<!ENTITY gitprjvers     "0.1.0">
-<!ENTITY gitupstream1   "https://github.com/&gitorg;/&gitproject;">
-<!ENTITY referencespec  "&obsrepoviewfile;&obshome1;/&gitproject;/&gitproject;.spec">
+<!ENTITY sampleprj      "my-first-obs-package">
+<!ENTITY prjvers        "0.1.0">
+<!ENTITY gitupstream1   "https://github.com/&gitorg;/&sampleprj;">
+<!ENTITY referencespec  "&obsrepoviewfile;&obshome1;/&sampleprj;/&sampleprj;.spec">
 
 
 <!-- ============================================================= -->

--- a/xml/factory.xml
+++ b/xml/factory.xml
@@ -6,12 +6,12 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="cha.obs.factory" os="opensuse">
+ xml:id="cha-obs-factory" os="opensuse">
  <title>openSUSE Factory</title>
  <info/>
  <para> This chapter describes how the development of the future openSUSE
   distribution is done within OBS. </para>
- <sect1 xml:id="cha.obs.factory.checkin">
+ <sect1 xml:id="cha-obs-factory-checkin">
   <title>openSUSE:Factory project</title>
   <para> The main project is openSUSE:Factory. This project is controlled by a
    small group which does review all submissions according to the policies.
@@ -20,7 +20,7 @@
   </para>
   <remark>TBD</remark>
  </sect1>
- <sect1 xml:id="cha.obs.factory.develprojects">
+ <sect1 xml:id="cha-obs-factory-develprojects">
   <title>Devel Projects</title>
   <para> The goal of openSUSE:Factory is to always have a working state. This
    is needed to allow all developer groups to use it as a base for testing

--- a/xml/obs_admin_appliance.xml
+++ b/xml/obs_admin_appliance.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.appliance"
+<sect1 version="5.1" xml:id="cha-obs-admin-appliance"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_admin_appliance.xml
+++ b/xml/obs_admin_appliance.xml
@@ -28,7 +28,7 @@
   <title>Image Types</title>
   <para> There are different types of &obsa; appliance images.</para>
    <table
-    xml:id="cha.obs.best-practices.appliance_types">
+    xml:id="cha-obs-best-practices-appliance-types">
     <title>Appliance Types</title>
     <tgroup cols="2" align="left">
      <thead>

--- a/xml/obs_admin_backend.xml
+++ b/xml/obs_admin_backend.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.backend"
+<sect1 version="5.1" xml:id="cha-obs-admin-backend"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_admin_backend.xml
+++ b/xml/obs_admin_backend.xml
@@ -19,7 +19,7 @@
     >man page</link>. For example, to restart the
    repository server, use:</para>
    <screen><command>systemctl restart obsrepserver.service</command></screen>
-  <table xml:id="tab.obs.service-names">
+  <table xml:id="tab-obs-service-names">
    <title>Service Names</title>
    <tgroup cols="2" align="left">
     <thead>

--- a/xml/obs_admin_components.xml
+++ b/xml/obs_admin_components.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.components"
+<sect1 version="5.1" xml:id="cha-obs-admin-components"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_admin_frontend.xml
+++ b/xml/obs_admin_frontend.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.frontend"
+<sect1 version="5.1" xml:id="cha-obs-admin-frontend"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_admin_integration.xml
+++ b/xml/obs_admin_integration.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.integration"
+<sect1 version="5.1" xml:id="cha-obs-admin-integration"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_admin_tools.xml
+++ b/xml/obs_admin_tools.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="cha.obs.admin.tools"
+<sect1 version="5.1" xml:id="cha-obs-admin-tools"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_ag_administration.xml
+++ b/xml/obs_ag_administration.xml
@@ -6,7 +6,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="obs.cha.administration">
+ xml:id="obs-cha-administration">
  <title>Administration</title>
  <info/>
  <xi:include href="obs_ag_tools.xml"/>

--- a/xml/obs_ag_administration.xml
+++ b/xml/obs_ag_administration.xml
@@ -18,19 +18,19 @@
  <xi:include href="obs_ag_unpublish_hooks.xml"/>
  <xi:include href="obs_ag_user_management.xml"/>
  <xi:include href="obs_ag_message_bus.xml"/>
- <sect1 xml:id="_backup">
+ <sect1 xml:id="backup">
   <title>Backup</title>
   <para>
     &obs; configuration and content needs usually a backup. The following explains
     suggested strategies and places considered for a backup.
   </para>
 
-  <sect2 xml:id="_backup_places">
+  <sect2 xml:id="backup-backup-places">
    <title>Places to consider</title>
    <para>The following is pointing to the places with admin configurations or user content.
          The default location places are considered here.
    </para>
-   <sect3 xml:id="_backup_configuration_frontend">
+   <sect3 xml:id="backup-backup-places-backup-configuration-frontend">
      <title>Frontend Configuration</title>
      <itemizedlist>
       <listitem>
@@ -43,41 +43,41 @@
     <para>The configuration is not changing usually. It is enough to backup it after config changes.
     </para>
    </sect3>
-   <sect3 xml:id="_backup_database_frontend">
+   <sect3 xml:id="backup-backup-places-backup-database-frontend">
      <title>Frontend Database</title>
      <para>The MySQL/MariaDB database backup can be done in different ways. Please consider the database
            manual for details. One possible way is to create dumps via mysqldump tool. The backup should be
            done at the same point of time as the source server. Inconsistencies can be resolved
            using the check_consistency tool.</para>
    </sect3>
-   <sect3 xml:id="_backup_backend_configuration">
+   <sect3 xml:id="backup-backup-places-backup-backend-configuration">
      <title>Backend Configuration</title>
      <para>The backend has a single configuration file which may got altered. This is by default
              /usr/lib/obs/server/BSConfig.pm . The file is not supposed to be changed usually and
              it can only be done by the system root user. A backup after a change is sufficient.
      </para>
    </sect3>
-   <sect3 xml:id="_backup_backend_content">
+   <sect3 xml:id="backup-backup-places-backup-backend-content">
      <title>Backend Content</title>
      <para>All backend content is below /srv/obs directory. This include the sources, build results and
            also all configuration changes done by the OBS admin users.
      </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="_backup_strategies">
+  <sect2 xml:id="backup-backup-strategies">
    <title>Backup strategies</title>
    <para>
      A backup is ideally taken only from a not running service. In real live this is
      usually not possible, so it is important to run a backup on a production system.
    </para>
-   <sect3 xml:id="_backup_strategy_database">
+   <sect3 xml:id="backup-backup-strategies-backup-strategy-database">
     <title>Database</title>
     <para>MySQL backup either directly from a non-primary node in the galera
     cluster (table dump locks the database during operation) or from a mysql slave
     attached to the cluster.
     </para>
    </sect3>
-   <sect3 xml:id="_backup_strategy_backend_sources">
+   <sect3 xml:id="backup-backup-strategies-backup-strategy-backend-sources">
     <title>Sources</title>
      <para>The sources are supposed to be backup at the same time as the database. This
            can get achieved by either having a dedicated instance for the source server
@@ -92,7 +92,7 @@
       </listitem>
      </itemizedlist>
    </sect3>
-   <sect3 xml:id="_backup_strategy_backend_binaries">
+   <sect3 xml:id="backup-backup-strategies-backup-strategy-backend-binaries">
     <title>Build Results</title>
     <para>Full backups via snapshots, either offered by the SAN storage or
     via LVM snapshot methods. Consistency is normally on repository level. Any inconsistency
@@ -103,13 +103,13 @@
   </sect2>
  </sect1>
 
- <sect1 xml:id="_restore">
+ <sect1 xml:id="restore">
   <title>Restore</title>
   <para>
     A restored system might contain inconsistencies if it was taken from a running service.
     These can be resolved as follows.
   </para>
-  <sect2 xml:id="_restore_database_inconsistencies">
+  <sect2 xml:id="restore-restore-database-inconsistencies">
    <title>Check and repair database inconsistencies</title>
    <para>If either database portions or sources got restored there are chances for inconsistencies.
    These can be found via
@@ -128,7 +128,7 @@
            <screen>&prompt.user;<command>cd /srv/www/obs/api/</command>
 &prompt.user;<command>./bin/rake fix_project project="YOUR_PROJECT"</command> </screen>
   </sect2>
-  <sect2 xml:id="_restore_binaries">
+  <sect2 xml:id="restore-restore-binaries">
    <title>Binaries</title>
    <para>All build results are evaluated by the scheduler. Therefore any inconsistency can be
            detected by the scheduler. One way is to enforce a cold start, which means that the
@@ -151,7 +151,7 @@
   </sect2>
  </sect1>
 
- <sect1 xml:id="_handle_data_corruption">
+ <sect1 xml:id="repair-data-corruption">
   <title>Repair Data Corruption</title>
   <para>
           On-disk data might be corrupted independent of a restore. For example due to power outage, filesystem

--- a/xml/obs_ag_build_targets.xml
+++ b/xml/obs_ag_build_targets.xml
@@ -3,12 +3,12 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="_managing_build_targets"
+<sect1 version="5.1" xml:id="managing-build-targets"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Managing Build Targets</title>
- <sect2 xml:id="_interconnect">
+ <sect2 xml:id="managing-build-targets-interconnect">
   <title>Interconnect</title>
   <para>Using another Open Build Service as source for build targets is the
    easiest way to start. The advantage is, that you save local resources and
@@ -26,7 +26,7 @@
    create a remote project using the <emphasis>osc meta prj</emphasis> command.
    A remote project differs from a local project as it has a <emphasis
     role="strong">remoteurl</emphasis> tag (see <xref
-    linkend="_project_meta_data"/>).</para>
+    linkend="meta-data-project-meta-data"/>).</para>
   <para>Example:</para>
   <screen>&lt;project name="openSUSE.org"&gt;
   &lt;title&gt;openSUSE.org Project Link&lt;/title&gt;
@@ -38,7 +38,7 @@ This project refers to projects hosted on the &osbs;
   <para>Sending this via osc to the server:</para>
   <screen>osc meta prj -m "add openSUSE.org remote" -F /tmp/openSUSE.org.prj</screen>
  </sect2>
- <sect2 xml:id="_importing_distributions">
+ <sect2 xml:id="managing-build-targets-importing-distributions">
  <title>Importing Distributions</title>
  <!-- do not describe old obs_mirror here anymore, it is misleading and broken -->
   <para>FIXME: describe how to do it using DoD</para>

--- a/xml/obs_ag_dispatch_priority.xml
+++ b/xml/obs_ag_dispatch_priority.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="_dispatch_priorities"
+<sect1 version="5.1" xml:id="dispatch-priorities"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -20,9 +20,9 @@
     ><emphasis>/build/_dispatchprios</emphasis></emphasis><emphasis
    role="strong">API</emphasis> call or via the <emphasis role="strong"
     ><emphasis>dispatch_adjust</emphasis></emphasis> array in the
-   <emphasis>BSConfig.pm</emphasis><xref linkend="_bsconfig_pm"/> configuration
+   <emphasis>BSConfig.pm</emphasis><xref linkend="bsconfig-pm"/> configuration
   file.</para>
- <sect2 xml:id="_build__dispatchprios_api_call">
+ <sect2 xml:id="dispatch-priorities-build-dispatchprios-api-call">
   <title>The <literal>/build/_dispatchprios</literal> API Call</title>
   <para>The <emphasis>/build/_dispatchprios</emphasis> API call allows an
    Admin to set a priority for defined projects and repositories using the HTTP
@@ -224,7 +224,7 @@
    </tgroup>
   </table>
  </sect2>
- <sect2 xml:id="_dispatch_adjust_array">
+ <sect2 xml:id="dispatch-priorities-dispatch-adjust-array">
   <title><literal>dispatch_adjust</literal> Array</title>
   <para>With the <emphasis role="strong"
      ><emphasis>dispatch_adjust</emphasis></emphasis> array in the

--- a/xml/obs_ag_high_level_overview.xml
+++ b/xml/obs_ag_high_level_overview.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.admin"
+<chapter version="5.1" xml:id="cha-obs-admin"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_ag_installation_and_configuration.xml
+++ b/xml/obs_ag_installation_and_configuration.xml
@@ -10,7 +10,7 @@
  <title>Installation and Configuration</title>
  <info/>
 
- <sect1 xml:id="_planning">
+ <sect1 xml:id="planning">
   <title>Planning</title>
   <para>For testing your own OBS instance, or for small setups, such as if you only
    want to package a few scripts into RPMS and create
@@ -30,7 +30,7 @@
    on one host, if it has sufficient resources.</para>
   <para>For flexibility and if you want some kind of high availability it is
    recommended to use virtualization for the different components.</para>
-  <sect2 xml:id="_resource_planning">
+  <sect2 xml:id="planning-resource-planning">
    <title>Resource Planning</title>
    <para>Normally, for an small or middle-sized installation, a setup with everything
     on one host (except workers) is sufficient. You should have a separate /srv
@@ -74,7 +74,7 @@
     worker hosts is more important than the other parts.</para>
   </sect2>
  </sect1>
- <sect1 xml:id="_simple_installation">
+ <sect1 xml:id="simple-installation">
   <title>Simple Installation</title>
   <para>In this document, we call "simple installation" an OBS installation where all OBS services are running on the same
    machine.</para>
@@ -86,7 +86,7 @@
   <para>Before you start the installation of the OBS, you should make sure that
    your hosts have the correct fully qualified hostname, and that DNS is working and
    can resolve all names.</para>
-  <sect2 xml:id="_backend_installation">
+  <sect2 xml:id="simple-installation-backend-installation">
    <title>Back-end Installation</title>
    <para>The back-end hosts all sources and built packages. It also schedules
     the jobs. To install it, install the "obs-server" package. After installation,
@@ -95,7 +95,7 @@
     the defaults should be good enough for simple cases.</para>
    <note>
     <para>
-      Read more about configuring the backend in <xref linkend="_distributed_setup"/>.
+      Read more about configuring the backend in <xref linkend="distributed-setup"/>.
     </para>
    </note>
    <para>The back-end consists of a number of systemd units (services):</para>
@@ -301,7 +301,7 @@ systemctl start obsrepserver.service
      outside. If the system is connected to an untrusted network, either block
      the ports with a firewall or do not run the commands at all.</para>
    </warning>
-   <sect3 xml:id="_cloud_upload_setup">
+   <sect3 xml:id="simple-installation-backend-installation-cloud-upload-setup">
     <title>Cloud Upload Setup</title>
     <para>In order to setup the Cloud Upload feature you will need to configure the tools required per each cloud provider.
       Right now we only support the AWS Amazon Cloud (<link xlink:href="https://aws.amazon.com"/>) and Microsoft Azure
@@ -341,9 +341,9 @@ our $clouduploadserver = "http://$hostname:5452";
         Having an incorrect system time will cause cloud uploads to fail.
       </para>
     </warning>
-    <sect4 xml:id="_aws">
+    <sect4 xml:id="simple-installation-backend-installation-cloud-upload-setup-aws">
      <title>AWS Amazon Cloud</title>
-     <sect5 xml:id="_aws_authentication_workflow">
+     <sect5 xml:id="simple-installation-backend-installation-cloud-upload-setup-aws-aws-authentication-workflow">
        <title>Authentication Workflow</title>
        <para>
          We are going to use the role based authentication provided by Amazon to enable the OBS instance to upload images to other user's accounts.
@@ -358,7 +358,7 @@ our $clouduploadserver = "http://$hostname:5452";
          The whole workflow is described in the <link xlink:href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html">AWS documentation</link>.
        </para>
      </sect5>
-     <sect5 xml:id="_aws_authentication_credential_setup">
+     <sect5 xml:id="simple-installation-backend-installation-cloud-upload-setup-aws-aws-authentication-credential-setup">
        <title>Credentials Setup</title>
        <para>
          For uploading images to AWS, OBS is using the <link xlink:href="https://aws.amazon.com/cli">AWS CLI</link> tool.
@@ -369,9 +369,9 @@ our $clouduploadserver = "http://$hostname:5452";
        </para>
      </sect5>
     </sect4>
-    <sect4 xml:id="_ms_azure">
+    <sect4 xml:id="simple-installation-backend-installation-cloud-upload-setup-ms-azure">
      <title>Microsoft Azure</title>
-     <sect5 xml:id="_ms_azure_authentication_workflow">
+     <sect5 xml:id="simple-installation-backend-installation-cloud-upload-setup-ms-azure-ms-azure-authentication-workflow">
       <title>Authentication Workflow</title>
       <para>
        The authentication is done via Microsoft's Active Directory. The user has to create a new application and needs to
@@ -391,7 +391,7 @@ our $clouduploadserver = "http://$hostname:5452";
        OBS communicates with the REST API of Microsoft Azure to authenticate and upload images.
       </para>
      </sect5>
-     <sect5 xml:id="_ms_azure_setup">
+     <sect5 xml:id="simple-installation-backend-installation-cloud-upload-setup-ms-azure-setup">
       <title>Configuration</title>
       <para>
        The <emphasis role="strong">Application ID</emphasis> and the <emphasis role="strong">Application Key</emphasis> will be stored encrypted in
@@ -407,7 +407,7 @@ openssl genrsa -out secret.pem
 openssl rsa -in secret.pem -out _pubkey -outform PEM -pubout
        </screen>
      </sect5>
-     <sect5 xml:id="_ms_azure_authentication_credential_setup">
+     <sect5 xml:id="simple-installation-backend-installation-cloud-upload-setup-aws-ms-azure-authentication-credential-setup">
       <title>Credentials setup</title>
       <para>
        It's important that the public key is named <emphasis role="strong">_pubkey</emphasis> and the secret key is named
@@ -417,11 +417,11 @@ openssl rsa -in secret.pem -out _pubkey -outform PEM -pubout
     </sect4>
    </sect3>
   </sect2>
-  <sect2 xml:id="_frontend_installation">
+  <sect2 xml:id="simple-installation-frontend-installation">
    <title>Front-end Installation</title>
    <para>You need to install the "obs-api" package for this and a MySQL
     server.</para>
-   <sect3 xml:id="_mysql_setup">
+   <sect3 xml:id="simple-installation-frontend-installation-mysql-setup">
     <title>MySQL Setup</title>
     <para>Make sure that the mysql server is started on every system reboot
      (use "insserv mysql" for permanent start). You should run
@@ -469,7 +469,7 @@ sudo RAILS_ENV="production" rake writeconfiguration
 sudo chown -R wwwrun.www log tmp</screen>
     <para>Now you are done with the database setup.</para>
    </sect3>
-   <sect3 xml:id="_apache_setup">
+   <sect3 xml:id="simple-installation-frontend-installation-apache-setup">
     <title>Apache Setup</title>
     <para>Now we need to configure the Web server. By default, you can reach
      the familiar web user interface and also api both on port 443 speaking
@@ -511,7 +511,7 @@ cat /srv/obs/certs/server.key /srv/obs/certs/server.crt \
     <screen>cp /srv/obs/certs/server.pem /etc/ssl/certs/
 c_rehash /etc/ssl/certs/</screen>
    </sect3>
-   <sect3 xml:id="_api_configuration">
+   <sect3 xml:id="simple-installation-frontend-installation-api-configuration">
     <title>API Configuration</title>
     <para>Check and edit <emphasis role="strong"
        >/srv/www/obs/api/config/options.yml</emphasis>
@@ -519,9 +519,9 @@ c_rehash /etc/ssl/certs/</screen>
     <para>If you change the hostnames/ips of the API, you need to adjust
       <emphasis role="strong">frontend_host</emphasis>
      accordingly. If you want to use LDAP, you need to change the LDAP settings
-     as well. Look at the <xref linkend="_user_and_group_management"/> for
+     as well. Look at the <xref linkend="user-and-group-management"/> for
      details. You will find examples and more details in the <xref
-      linkend="_configuration_files"/>.</para>
+      linkend="configuration-files"/>.</para>
     <para>It is strongly recommended to enable</para>
     <screen>use_xforward: true</screen>
     <para>as well here, to tell Rails to forward requests to the back-end for
@@ -541,7 +541,7 @@ systemctl start memcached.service</screen>
      online configuration steps.</para>
    </sect3>
   </sect2>
-  <sect2 xml:id="_online_configuration">
+  <sect2 xml:id="simple-installation-online-configuration">
    <title>Online Configuration</title>
    <para>To customize the OBS instance you may need to configure some settings
     via the OBS API and Web user interface.</para>
@@ -624,7 +624,7 @@ cat /tmp/obs.config
    <para>If you want to use an interconnect to another OBS instance to reuse
     the build targets you can do this as Admin via the Web UI or create a
     project with a <emphasis role="strong">remoteurl</emphasis> tag (see <xref
-     linkend="_project_meta_data"/>)</para>
+     linkend="meta-data-project-meta-data"/>)</para>
    <screen>&lt;project name="openSUSE.org"&gt;
   &lt;title&gt;openSUSE.org Project&lt;/title&gt;
   &lt;description&gt;
@@ -641,7 +641,7 @@ openSUSE:12.3 project as specified on the opensuse.org Build Service.
     this:</para>
    <screen>osc -c ~/.obsadmin_osc.rc meta prj openSUSE.org -F /tmp/openSUSE.org.meta</screen>
    <para>You also can import binary distribution, see <xref
-     linkend="_importing_distributions"/> for this.</para>
+     linkend="managing-build-targets-importing-distributions"/> for this.</para>
    <para>The OBS has a list of available distributions used for build. This
     list is displayed to user, if they are adding repositories to their
     projects. This list can be managed via the API path /distributions</para>
@@ -664,7 +664,7 @@ openSUSE:12.3 project as specified on the opensuse.org Build Service.
    <screen>osc -c ~/.obsadmin_osc.rc api /distributions -T /tmp/distributions.xml</screen>
   </sect2>
  </sect1>
- <sect1 xml:id="_worker_farm">
+ <sect1 xml:id="worker-farm">
   <title>Worker Farm</title>
   <para>To not burden your OBS back-end daemons with the unpredictable load
    package builds can produce (think someone builds a monstrous package like
@@ -685,12 +685,12 @@ openSUSE:12.3 project as specified on the opensuse.org Build Service.
     <emphasis role="strong">OBS_SRC_SERVER</emphasis>, <emphasis role="strong"
     >OBS_REPO_SERVERS</emphasis> and <emphasis role="strong"
     >OBS_WORKER_INSTANCES</emphasis> need to be set. More details in the <xref
-    linkend="_configuration_files"/>.</para>
+    linkend="configuration-files"/>.</para>
   <para>start the worker:</para>
   <screen>systemctl enable obsworker
 systemctl start obsworker</screen>
  </sect1>
- <sect1 xml:id="_distributed_setup">
+ <sect1 xml:id="distributed-setup">
   <title>Distributed Setup</title>
   <para>All OBS back-end daemons can also be started on individual machines in
    your network. Also, the front-end Web server and the MySQL server can run on
@@ -825,15 +825,15 @@ systemctl start obswarden.service</screen>
     role="strong">OBS_REPO_SERVERS</emphasis> variable. You can also define
    workers with a subset of the repo servers to prioritize partitions.</para>
  </sect1>
- <sect1 xml:id="_monitoring">
+ <sect1 xml:id="monitoring">
   <title>Monitoring</title>
   <para>In this chapter you will find some general monitoring instructions for
    the Open Build Service. All examples are based on Nagios plugins, but the
    information provided should be easily adaptable for other monitoring
    solutions.</para>
-  <sect2 xml:id="_endpoint_checks">
+  <sect2 xml:id="monitoring-endpoint-checks">
    <title>Endpoint Checks</title>
-   <sect3 xml:id="_http_checks_check_if_the_http_server_responds">
+   <sect3 xml:id="monitoring-endpoint-checks-http-checks-check-if-the-http-server-responds">
     <title>HTTP Checks: Checking Whether the HTTP Server Responds</title>
     <para>This check will output a critical if the HTTP server with ip address
      172.19.19.19 (-I 172.19.19.19) listening on port 80 (-p 80) does not
@@ -871,11 +871,11 @@ systemctl start obswarden.service</screen>
     </orderedlist>
    </sect3>
   </sect2>
-  <sect2 xml:id="_common_checks">
+  <sect2 xml:id="monitoring-common-checks">
    <title>Common Checks</title>
    <para>This is a list of common checks that should be run on each individual
     server.</para>
-   <sect3 xml:id="_disk_space_check_for_available_disk_space">
+   <sect3 xml:id="monitoring-common-checks-disk-space-check-for-available-disk-space">
     <title>Disk Space: Checking Available Disk Space</title>
     <para>This check will output a warning if less than 10 percent disk space
      is available (-w 10) and output a critical if less than 5 percent disk
@@ -883,7 +883,7 @@ systemctl start obswarden.service</screen>
      systems with type <emphasis>none</emphasis> (-x none).</para>
     <screen>check_disk -w 10 -c 5 -x none</screen>
    </sect3>
-   <sect3 xml:id="_memory_usage_check_for_available_memory">
+   <sect3 xml:id="monitoring-common-checks-memory-usage-check-for-available-memory">
     <title>Memory Usage: Checking Available Memory</title>
     <para>This check will output a warning if less than 10 percent memory is
      available (-w 10) and output a critical if less than 5 percent memory is
@@ -894,7 +894,7 @@ systemctl start obswarden.service</screen>
       >https://exchange.nagios.org/</link>.</para>
     <screen>check_mem.pl -f -C -w 10 -c 5</screen>
    </sect3>
-   <sect3 xml:id="_ntp_check_date_and_time">
+   <sect3 xml:id="monitoring-common-checks-ntp-check-date-and-time">
     <title>NTP: Checking Date and Time</title>
     <para>This check will compare the local time with the time provided by the
      NTP server pool.ntp.org (-H pool.ntp.org). It will output a warning if the
@@ -902,7 +902,7 @@ systemctl start obswarden.service</screen>
      differs by 1 seconds (-c 1).</para>
     <screen>check_ntp_time -H pool.ntp.org -w 0.5 -c 1</screen>
    </sect3>
-   <sect3 xml:id="_ping_check_that_the_server_is_alive">
+   <sect3 xml:id="monitoring-common-checks-ping-check-that-the-server-is-alive">
     <title>Ping: Checking That the Server Is Alive</title>
     <para>This plugin checks if the server responds to a ping request and it
      will output a warning if the respond time exceeds 200ms or 30 percent
@@ -910,7 +910,7 @@ systemctl start obswarden.service</screen>
      exceeds 500ms or 60 percent package loss.</para>
     <screen>check_icmp -H server -w 200.0,30% -c 500.0,60%</screen>
    </sect3>
-   <sect3 xml:id="_load_check_the_load_on_the_server">
+   <sect3 xml:id="monitoring-common-checks-load-check-the-load-on-the-server">
     <title>Load: Checking the Load on the Server</title>
     <para>This check will output a warning if the load value exceeded 7.0 in
      the last minute, 6.0 in the last 5 minutes or 5.0 in the last 15 minutes
@@ -919,7 +919,7 @@ systemctl start obswarden.service</screen>
      minutes (-c 12.0,8.0,6.0).</para>
     <screen>check_load -w 7.0,6.0,5.0 -c 12.0,8.0,6.0</screen>
    </sect3>
-   <sect3 xml:id="_disk_health_check_the_health_of_local_hard_disks">
+   <sect3 xml:id="monitoring-common-checks-disk-health-check-the-health-of-local-hard-disks">
     <title>Disk Health: Checking the Health of Local Hard Disks</title>
     <para>This check is only relevant on physical systems with local storage
      attached to it. It will check the disk status utilizing the S.M.A.R.T
@@ -930,9 +930,9 @@ systemctl start obswarden.service</screen>
     <screen>check_smartmon --drive /dev/sda --drive /dev/sdb</screen>
    </sect3>
   </sect2>
-  <sect2 xml:id="_other_checks">
+  <sect2 xml:id="monitoring-other-checks">
    <title>Other Checks</title>
-   <sect3 xml:id="_mysql_check_that_the_mysql_database_is_responding">
+   <sect3 xml:id="monitoring-other-checks-mysql-check-that-the-mysql-database-is-responding">
     <title>MySQL: Checking That the MySQL Database Is Responding</title>
     <para>This check will check that the MySQL database server is running and
      that the database <emphasis>api_production</emphasis> is available.</para>
@@ -947,7 +947,7 @@ systemctl start obswarden.service</screen>
      </listitem>
     </orderedlist>
    </sect3>
-   <sect3 xml:id="_backup_status_check_that_a_valid_backup_is_avilable">
+   <sect3 xml:id="monitoring-other-checks-backup-status-check-that-a-valid-backup-is-avilable">
     <title>Backup Status: Checking That a Valid Backup Is Available</title>
     <para>It is always advisable to check that the last backup run was
      successful and a recent backup is available. The check itself depends on

--- a/xml/obs_ag_installation_and_configuration.xml
+++ b/xml/obs_ag_installation_and_configuration.xml
@@ -6,7 +6,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="obs.cha.installation_and_configuration">
+ xml:id="obs-cha-installation-and-configuration">
  <title>Installation and Configuration</title>
  <info/>
 

--- a/xml/obs_ag_k8s_worker.xml
+++ b/xml/obs_ag_k8s_worker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<sect1 xml:id="_worker_in_kubernetes_" xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<sect1 xml:id="worker-in-kubernetes" xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
         <title>Worker in Kubernetes</title>
         <warning>
             <title>Alpha Implementation</title>

--- a/xml/obs_ag_k8s_worker.xml
+++ b/xml/obs_ag_k8s_worker.xml
@@ -16,7 +16,7 @@
         <para>So, <literal>/dev/kvm</literal> can be made available to containers via Kubernetes using device plugin API (<link xl:href="https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/"/>).</para>
         <para>One of the implementations of K8s devices plugin for KVM is available here : <link xl:href="https://github.com/kubevirt/kubernetes-device-plugins" /></para>
     <procedure>
-    <step xml:id="k8s.worker.getkvm">
+    <step xml:id="k8s-worker-getkvm">
         <para>Use the following manifest to deploy the KVM device plugin in a container.</para>
         <para>This plugin is packaged as <literal>k8s-device-plugin-kvm</literal> and corresponding container built here:
         <link xl:href="https://build.opensuse.org/package/show/home:sjamgade:branches:devel:CaaSP:Head:ControllerNode/kubernetes-device-plugins-docker"/></para>
@@ -58,13 +58,13 @@ spec:
            path: /var/lib/kubelet/device-plugins
        </screen>
     </step>
-    <step xml:id="k8s.worker.buildworker">
+    <step xml:id="k8s-worker-buildworker">
         <para>Build container image of the build service locally and load it to all worker nodes. There is sample project file here:
             <link xl:href="https://build.opensuse.org/package/show/home:sjamgade:branches:OBS:Server:Unstable/OBS-Appliance"/> 
             <literal>docker load &lt; "/path/to/docker.archive.tar.gz" </literal>
          </para>
     </step>
-    <step xml:id="k8s.worker.loadworker">
+    <step xml:id="k8s-worker-loadworker">
         <para>Use the following manifest to deploy the build service worker.</para>
         <para>Here ports are hard-coded to allow easy integration with local kubelet without requiring a separate ingress-controller</para>
         <screen>
@@ -139,7 +139,7 @@ spec:
       nodePort: 32516
         </screen>
     </step>
-    <step xml:id="k8s.worker.createworkerconfig">
+    <step xml:id="k8s-worker-createworkerconfig">
         <para>Save the following into a file <literal>launchworker.sh</literal>. Later use this file to launch the worker. Make sure you uncomment the OBS_REPO_SERVERS line and change the IP address to your build servers address</para>
         <screen>
 cat &lt;&lt; EOH &gt; /etc/buildhost.config
@@ -159,7 +159,7 @@ EOH
 obsworker restart
         </screen>
     </step>
-    <step xml:id="k8s.worker.startworker">
+    <step xml:id="k8s-worker-startworker">
         <para>Use the following command to launch the build service worker.</para>
         <screen>
 cat launchworker.sh | kubectl exec -i -t test-worker-pod bash 

--- a/xml/obs_ag_message_bus.xml
+++ b/xml/obs_ag_message_bus.xml
@@ -6,13 +6,13 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="_message_bus">
+ xml:id="message-bus">
  <title>Message Bus for Event Notifications</title>
  <para>The OBS has an integrated notification subsystem for sending events that are happening in our app through a message bus.
    We have chosen <link xlink:href="https://www.rabbitmq.com/">RabbitMQ</link> as our message bus server technology based on the
    <link xlink:href="https://www.amqp.org/">AMQP</link> protocol.
  </para>
- <sect2 xml:id="_rabbit_mq">
+ <sect2 xml:id="message-bus-rabbit-mq">
   <title>RabbitMQ</title>
   <para>
     RabbitMQ claims to be <emphasis>"the most popular open source message broker"</emphasis>. Meaning that it can deliver asynchronous messages in many
@@ -22,7 +22,7 @@
     RabbitMQ is lightweight and easy to deploy on premises and in the cloud. It supports multiple messaging protocols too.
     And can be deployed in distributed and federated configurations to meet high-scale, high-availability requirements.
   </para>
-  <sect3 xml:id="_rabbit_mq_configuration">
+  <sect3 xml:id="message-bus-rabbit-mq-rabbit-mq-configuration">
    <title>Configuration</title>
    <para>
     Currently the RabbitMQ configuration is in the file <filename>options.yml</filename>.

--- a/xml/obs_ag_overview_filesystem.xml
+++ b/xml/obs_ag_overview_filesystem.xml
@@ -10,11 +10,11 @@
  <title>File System Overview</title>
  <info/>
 
- <sect1 xml:id="_configuration_files">
+ <sect1 xml:id="configuration-files">
   <title>Configuration Files</title>
-  <sect2 xml:id="_frontend_configuration">
+  <sect2 xml:id="configuration-files-frontend-configuration">
    <title>Front-end Configuration</title>
-   <para>The front-end is configured with 4 files:</para>
+   <para>The front-end is configured with four files:</para>
    <itemizedlist>
     <listitem>
      <para>/srv/www/obs/api/config/database.yml</para>
@@ -29,7 +29,7 @@
      <para>/etc/apache2/vhosts.d/obs.conf</para>
     </listitem>
    </itemizedlist>
-   <sect3 xml:id="_database_yml">
+   <sect3 xml:id="configuration-files-frontend-configuration-database-yml">
     <title><filename>database.yml</filename></title>
     <para>This file has the information needed to access the database. It
      contain credentials for the database access and should be only readable by
@@ -174,7 +174,7 @@
      </tgroup>
     </table>
    </sect3>
-   <sect3 xml:id="_options_yml">
+   <sect3 xml:id="configuration-files-frontend-configuration-options-yml">
     <title><filename>options.yml</filename></title>
     <para>The configuration file /srv/www/obs/api/config/options.yml is the
      default configuration file for the Open Build Service Web UI and API. It
@@ -637,7 +637,7 @@ development:
   memcached_host: cache
 </screen>
    </sect3>
-   <sect3 xml:id="_feature_yml">
+   <sect3 xml:id="configuration-files-frontend-configuration-feature-yml">
     <title><filename>feature.yml</filename></title>
     <para>The configuration file /srv/www/obs/api/config/feature.yml
      contains the default configuration about features that can be enabled or
@@ -727,7 +727,7 @@ test:
 ]]>
     </screen>
    </sect3>
-   <sect3 xml:id="_apache_vhost_obs_conf">
+   <sect3 xml:id="configuration-files-frontend-configuration-apache-vhost-obs-conf">
     <title>Apache Virtual Host <filename>obs.conf</filename></title>
     <para>The Apache configuration depends on the Apache version and which
      extra options are used, so use the documentation of the Apache version you
@@ -837,7 +837,7 @@ LimitRequestFieldsize 20000
 &lt;/VirtualHost&gt;</screen>
    </sect3>
   </sect2>
-  <sect2 xml:id="_backend_configuration">
+  <sect2 xml:id="configuration-files-backend-configuration">
    <title>Back-end Configuration</title>
    <para>The Back-end is configured with 2 files:</para>
    <itemizedlist>
@@ -850,7 +850,7 @@ LimitRequestFieldsize 20000
       global variables </para>
     </listitem>
    </itemizedlist>
-   <sect3 xml:id="_etc_sysconfig_obs_server">
+   <sect3 xml:id="configuration-files-backend-configuration-etc-sysconfig-obs-server">
     <title><filename>/etc/sysconfig/obs-server</filename></title>
     <para>This script is used to set up the basic paths and the worker. the
      most important settings are the <emphasis role="strong"
@@ -1745,7 +1745,7 @@ OBS_ROOT_SSHD_KEY_URL=""
 #
 OBS_WORKER_SCRIPT_URL=""</screen>
    </sect3>
-   <sect3 xml:id="_bsconfig_pm">
+   <sect3 xml:id="bsconfig-pm">
     <title>BSConfig.pm</title>
     <para>This file is a perl module used by most back-end scripts, it
      mainly defines global variables. Since it is a perl module, after changes
@@ -2467,7 +2467,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_distributed_setup"/>
+         <para>see <xref linkend="distributed-setup"/>
          </para>
         </entry>
        </row>
@@ -2482,7 +2482,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_distributed_setup"/>
+         <para>see <xref linkend="distributed-setup"/>
          </para>
         </entry>
        </row>
@@ -2497,7 +2497,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_distributed_setup"/>
+         <para>see <xref linkend="distributed-setup"/>
          </para>
         </entry>
        </row>
@@ -2512,7 +2512,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_dispatch_adjust_array"/>
+         <para>see <xref linkend="dispatch-priorities-dispatch-adjust-array"/>
          </para>
         </entry>
        </row>
@@ -2527,7 +2527,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para><literal>0</literal> 1</para>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_publisher_hooks"/>
+         <para>see <xref linkend="publisher-hooks"/>
          </para>
         </entry>
        </row>
@@ -2542,7 +2542,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_publisher_hooks"/>
+         <para>see <xref linkend="publisher-hooks"/>
          </para>
         </entry>
        </row>
@@ -2557,7 +2557,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para><literal>0</literal> 1</para>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_unpublisher_hooks"/>
+         <para>see <xref linkend="unpublisher-hooks"/>
          </para>
         </entry>
        </row>
@@ -2572,7 +2572,7 @@ OBS_WORKER_SCRIPT_URL=""</screen>
          <para/>
         </entry>
         <entry align="left" valign="top">
-         <para>see <xref linkend="_unpublisher_hooks"/>
+         <para>see <xref linkend="unpublisher-hooks"/>
          </para>
         </entry>
        </row>
@@ -2798,9 +2798,9 @@ if (-r $hostconfig) {
    </sect3>
   </sect2>
  </sect1>
- <sect1 xml:id="_log_files">
+ <sect1 xml:id="log-files">
   <title>Log Files</title>
-  <sect2 xml:id="_frontend">
+  <sect2 xml:id="log-files-frontend">
    <title>Front-end</title>
    <para>The front-end log files are found under
      <emphasis>/srv/www/obs/api/log</emphasis>.</para>
@@ -2832,7 +2832,7 @@ if (-r $hostconfig) {
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2 xml:id="_backend">
+  <sect2 xml:id="log-files-backend">
    <title>Back-end</title>
    <para>The back-end log files are found by default under
      <emphasis>/srv/obs/log/</emphasis>.</para>
@@ -2884,7 +2884,7 @@ if (-r $hostconfig) {
    </itemizedlist>
   </sect2>
  </sect1>
- <sect1 xml:id="_src_obs_tree">
+ <sect1 xml:id="src-obs-tree">
   <title><filename>/srv/obs</filename> Tree</title>
   <para>The default back-end data directory is located under
     <emphasis>/srv/obs/</emphasis>. Here are a bunch of subdirectories used for
@@ -2894,7 +2894,7 @@ if (-r $hostconfig) {
    which stores the global OBS configuration for the back-end. You should not
    modify this file directly, but use the API /configuration interface instead,
    since this information needs to kept in sync with the front-end.</para>
-  <sect2 xml:id="_build_directory">
+  <sect2 xml:id="src-obs-tree-build-directory">
    <title><filename>build</filename> Directory</title>
    <para>In this subdirectory managed by the repo server daemon, all
     repository data, metadata and build results are stored in a hierarchical
@@ -2928,29 +2928,29 @@ if (-r $hostconfig) {
 │           ├── srtp
 │           └── wget</screen>
   </sect2>
-  <sect2 xml:id="_cloudupload_directory">
+  <sect2 xml:id="src-obs-tree-cloudupload-directory">
    <title><filename>cloudupload</filename> Directory</title>
    <para>Info for cloud upload jobs is stored here, it has a subdir named <emphasis>done</emphasis> for storing the already finished jobs.</para>
   </sect2>
-  <sect2 xml:id="_db_directory">
+  <sect2 xml:id="src-obs-tree-db-directory">
    <title><filename>db</filename> Directory</title>
    <para>Back-end database root directory use by the source server, repo
     server scheduler and publisher. Nobody should touch this.</para>
   </sect2>
-  <sect2 xml:id="_diffcache_directory">
+  <sect2 xml:id="src-obs-tree-diffcache-directory">
    <title><filename>diffcache</filename> Directory</title>
    <para>Cache for source server compare operations.</para>
   </sect2>
-  <sect2 xml:id="_events_directory">
+  <sect2 xml:id="src-obs-tree-events-directory">
    <title><filename>events</filename> Directory</title>
    <para>Communication between services.</para>
   </sect2>
-  <sect2 xml:id="_info_directory">
+  <sect2 xml:id="src-obs-tree-info-directory">
    <title><filename>info</filename> Directory</title>
    <para>Scheduler information managed by the scheduler and used by the repo
     server.</para>
   </sect2>
-  <sect2 xml:id="_jobs_directory">
+  <sect2 xml:id="src-obs-tree-jobs-directory">
    <title><filename>jobs</filename> Directory</title>
    <para>The build jobs are stored in the /srv/obs/jobs directory. They are
     organized bybuild architecture:</para>
@@ -2963,34 +2963,34 @@ if (-r $hostconfig) {
    <para>The jobs/load file contains statistical data about the build
     jobs.</para>
   </sect2>
-  <sect2 xml:id="_log_directory">
+  <sect2 xml:id="src-obs-tree-log-directory">
    <title><filename>log</filename> Directory</title>
    <para>Contains the log files of the back-end daemons.</para>
   </sect2>
-  <sect2 xml:id="_projects_directory">
+  <sect2 xml:id="src-obs-tree-projects-directory">
    <title><filename>projects</filename> Directory</title>
    <para>Contains the project hierarchy and metadata under revision
     control.</para>
   </sect2>
-  <sect2 xml:id="_remotecache_directory">
+  <sect2 xml:id="src-obs-tree-remotecache-directory">
    <title><filename>remotecache</filename> Directory</title>
    <para>Cache for remote repository information.</para>
   </sect2>
-  <sect2 xml:id="_repos_directory">
+  <sect2 xml:id="src-obs-tree-repos-directory">
    <title><filename>repos</filename> Directory</title>
    <para>Directory managed by the publisher to collect build results, also
     used by the repo server and scheduler to find build results.</para>
   </sect2>
-  <sect2 xml:id="_repos_sync_directory">
+  <sect2 xml:id="src-obs-tree-repos-sync-directory">
    <title><filename>repos_sync</filename> Directory</title>
    <para>Directory with files pointing to the project root directories,
     helper for publisher rsync.</para>
   </sect2>
-  <sect2 xml:id="_run_directory">
+  <sect2 xml:id="src-obs-tree-run-directory">
    <title><filename>run</filename> Directory</title>
    <para>State and lock information for the back-end daemons</para>
   </sect2>
-  <sect2 xml:id="_sources_directory">
+  <sect2 xml:id="src-obs-tree-sources-directory">
    <title><filename>sources</filename> Directory</title>
    <para>All package sources under revision control in one directory per
     package, managed by the source server. Package sources are by default
@@ -3011,24 +3011,24 @@ if (-r $hostconfig) {
 ├── :service
 └── :upload</screen>
   </sect2>
-  <sect2 xml:id="_trees_directory">
+  <sect2 xml:id="src-obs-tree-trees-directory">
    <title><filename>trees</filename> Directory</title>
    <para>Revision control data for project and packages, managed by the
     source server.</para>
   </sect2>
-  <sect2 xml:id="_upload_directory">
+  <sect2 xml:id="src-obs-tree-upload-directory">
    <title><filename>upload</filename> Directory</title>
    <para>Temporary directory for uploading files for other back-end
     components.</para>
   </sect2>
-  <sect2 xml:id="_workers_directory">
+  <sect2 xml:id="src-obs-tree-workers-directory">
    <title><filename>workers</filename> Directory</title>
    <para>Worker information</para>
   </sect2>
  </sect1>
- <sect1 xml:id="_meta_data">
+ <sect1 xml:id="meta-data">
   <title>Metadata</title>
-  <sect2 xml:id="_obs_revision_control">
+  <sect2 xml:id="meta-data-obs-revision-control">
    <title>&obsa; Revision Control</title>
    <para>This section gives a short generic overview how the revision
     information are stored in the OBS back-end for packages and projects. The
@@ -3038,7 +3038,7 @@ if (-r $hostconfig) {
      <emphasis>/srv/obs/sources</emphasis> directories. The revision
     information is stored in separate files by the Source Server in the
      <emphasis>/srv/obs/projects directory</emphasis>.</para>
-   <sect3 xml:id="_obs_revision_control_files">
+   <sect3 xml:id="meta-data-obs-revision-control-obs-revision-control-files">
     <title>OBS revision control files</title>
     <para>The revision information is stored in simple CSV like file format
      with a bar (|) as delimiter between the 8 columns. The files do have the
@@ -3198,7 +3198,7 @@ if (-r $hostconfig) {
 0a17daaa913df9e50ee65e83a1898363  package1.spec
 1f810b3521242a98333b7bbf6b2b7ef7  test1.sh</screen>
    </sect3>
-   <sect3 xml:id="_obs_revision_api">
+   <sect3 xml:id="meta-data-obs-revision-control-obs-revision-api">
     <title>&obsa; Revision API</title>
     <para>The revision info can be retrieved via API calls for the specific
      package, for example, using
@@ -3210,7 +3210,7 @@ if (-r $hostconfig) {
      "comment=some+comment" can be used to set a commit message.</para>
    </sect3>
   </sect2>
-  <sect2 xml:id="_project_meta_data">
+  <sect2 xml:id="meta-data-project-meta-data">
    <title>Project Metadata</title>
    <para>Project metadata are XML files containing the meta project
     information, such as title, description, related user and groups with
@@ -3445,7 +3445,7 @@ if (-r $hostconfig) {
   &lt;/repository&gt;
 &lt;/project&gt;</screen>
   </sect2>
-  <sect2 xml:id="_package_meta_data">
+  <sect2 xml:id="meta-data-package-meta-data">
    <title>Package Metadata</title>
    <para>XML file about package meta information, like Title, description,
     related user and groups with roles, build settings, publish settings, debug
@@ -3468,7 +3468,7 @@ if (-r $hostconfig) {
   &lt;/debuginfo&gt;
 &lt;/package&gt;</screen>
   </sect2>
-  <sect2 xml:id="_attribute_meta_data">
+  <sect2 xml:id="meta-data-attribute-meta-data">
    <title>Attribute Metadata</title>
    <para>Attributes can be used to add special information to packages.
     Attributes can be used to trigger special actions.</para>
@@ -3483,7 +3483,7 @@ if (-r $hostconfig) {
   &lt;/attribute&gt;
 &lt;/attributes&gt;</screen>
   </sect2>
-  <sect2 xml:id="_job_files">
+  <sect2 xml:id="meta-data-job-files">
    <title>Job Files</title>
    <para>Jobs are stored by the scheduler in the
      <filename>/srv/obs/jobs</filename> directory and contain the build setup

--- a/xml/obs_ag_overview_filesystem.xml
+++ b/xml/obs_ag_overview_filesystem.xml
@@ -6,7 +6,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="obs.cha.overview_filesystem">
+ xml:id="obs-cha-overview-filesystem">
  <title>File System Overview</title>
  <info/>
 

--- a/xml/obs_ag_publish_hooks.xml
+++ b/xml/obs_ag_publish_hooks.xml
@@ -6,7 +6,7 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="_publisher_hooks">
+ xml:id="publisher-hooks">
  <title>Publisher Hooks</title>
  <para>The job of the publisher service is to publish the built packages
   and/or images by creating repositories that are made available through a web
@@ -15,7 +15,7 @@
   to different servers or do anything with them that comes to mind. These
   scripts are called <emphasis role="strong"><emphasis>publisher
     hooks</emphasis></emphasis>.</para>
- <sect2 xml:id="_publisher_hooks_configuration">
+ <sect2 xml:id="publisher-hooks-publisher-hooks-configuration">
   <title>Configuring Publisher Hooks</title>
   <para>Hooks are configured via the configuration file
     <emphasis>/usr/lib/obs/server/BSConfig.pm</emphasis>, where one script per
@@ -99,9 +99,9 @@ our $publishedhook = {
    script.</para>
   <para>The scripts are called without a timeout.</para>
  </sect2>
- <sect2 xml:id="_example_publisher_scripts">
+ <sect2 xml:id="publisher-hooks-example-publisher-scripts">
   <title>Example Publisher Scripts</title>
-  <sect3 xml:id="_simple_publisher_hook">
+  <sect3 xml:id="publisher-hooks-example-publisher-scripts-simple-publisher-hook">
    <title>Simple Publisher Hook</title>
    <para>The following example script ignores the packages that have changed
     and copies all RPMs from the repository directory to a target
@@ -120,7 +120,7 @@ rsync -a --log-file=$LOGFILE --mkpath $PATH_TO_REPO/ $DST_REPO_DIR/$PRJ_PATH/</s
    <screen>$ sudo -u obsrun /usr/local/bin/publish-hook.sh Product/SLES11-SP1 \
     /srv/obs/repos/Product/SLE11-SP1</screen>
   </sect3>
-  <sect3 xml:id="_advanced_publisher_hook">
+  <sect3 xml:id="publisher-hooks-example-publisher-scripts-advanced-publisher-hook">
    <title>Advanced Publisher Hook</title>
    <para>The following example script reads the destination path from a
     parameter that is configured with the hook script:</para>

--- a/xml/obs_ag_security_concepts.xml
+++ b/xml/obs_ag_security_concepts.xml
@@ -6,11 +6,11 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="obs.cha.security_concepts">
+ xml:id="obs-cha-security-concepts">
  <title>Security Concepts</title>
  <info/>
 
- <sect1 xml:id="general_paradigm">
+ <sect1 xml:id="general-paradigm">
   <title>General Paradigm</title>
   <para>The general paradigm of &obs; is to host all content on its own. Every part 
         required to rebuild a package is hosted in &obs; to guarantee reproducibility.
@@ -18,11 +18,11 @@
         However, optional services to integrate remote resources exist as well. These resources
         are either mirrored and stored in revision control system or just cached.
         </para>
-  <sect2 xml:id="network_setup">
+  <sect2 xml:id="network-setup">
    <title>Frontend</title>
    <para>The API and web interface frontends is the only part which must be accessible from
 	   public network. A SSL/TLS certificate is highly recommended.</para>
-   <sect3 xml:id="network_access">
+   <sect3 xml:id="network-access">
     <title>Access to Mirror Servers</title>
     <para>The following services require access to stage servers. These servers
           can be used to publish content without the need to make &obs; server parts
@@ -40,7 +40,7 @@
      </listitem>
     </itemizedlist>
    </sect3>
-   <sect3 xml:id="public_network_access">
+   <sect3 xml:id="public-network-access">
     <title>Access to the Public Network</title>
     <para>The following services may require access to the public network.</para>
     <itemizedlist>
@@ -67,14 +67,14 @@
      </listitem>
     </itemizedlist>
    </sect3>
-   <sect3 xml:id="worker_network">
+   <sect3 xml:id="worker-network">
     <title>Worker network</title>
     <para>It is recommended to run the &obs; workers in an isolated network. This is
           an additional security mechanism in case of a security breach on a worker.
           This network needs access to the source and repository servers of the &obs;
           backend, but nowhere else.</para>
    </sect3>
-   <sect3 xml:id="signd_network">
+   <sect3 xml:id="signd-network">
     <title>Signer network</title>
     <para>It is recommended to run the signd on an isolated host. The signer services
           need to stay on the &obs; backend servers, they are just used for scheduling
@@ -88,7 +88,7 @@
           backend server components (source server and publisher).</para>
    </sect3>
   </sect2>
-  <sect2 xml:id="build_env">
+  <sect2 xml:id="build-env">
    <title>Build Environment</title>
    <para>The build environment is created by obsworker instances via the build script.
          Inside the build instances unverified and potentially harmful code is executed.
@@ -112,7 +112,7 @@
          source packages are rebuildable without root permissions.
          </para>
   </sect2>
-  <sect2 xml:id="source_revision_system">
+  <sect2 xml:id="source-revision-system">
    <title>Source Revision System</title>
    <para>The source revision storage system is part of &obs;. The identification of sources
          still happens using MD5 sums for historic reasons. MD5 is considered to be still
@@ -126,7 +126,7 @@
          builds, but it should be avoided for base projects.
          </para>
   </sect2>
-  <sect2 xml:id="permission_handling">
+  <sect2 xml:id="permission-handling">
    <title>Permission Handling</title>
    <para>Authorization for write operations is done via the maintainer role on package
          or project level. On project level the projects are organized in namespaces
@@ -136,7 +136,7 @@
          top level namespaces (for example, openSUSE: namespace in our reference instance).
    </para>
   </sect2>
-  <sect2 xml:id="signature_handling">
+  <sect2 xml:id="signature-handling">
    <title>Signature Handling</title>
    <para>Signatures are used to proof the origin of a shipment independent of
           &obs; instance. Once the <systemitem>signd</systemitem> daemon has
@@ -181,17 +181,17 @@
    </para>
   </sect2>
  </sect1>
- <sect1 xml:id="trust_zones">
+ <sect1 xml:id="trust-zones">
   <title>Trust Zones </title>
   <para>&OBS; components deal with different trust zones. These are
         separated via network or virtualization mechanics.
   </para>
 
-  <sect2 xml:id="public_zone">
+  <sect2 xml:id="public-zone">
    <title>Public Zones</title>
    <para>Public zones are areas where any code under user control is running.
    </para>
-   <sect3 xml:id="external_network">
+   <sect3 xml:id="external-network">
     <title>External Network</title>
     <para>
       This can be the public Internet if the &obs; instance is a public
@@ -201,7 +201,7 @@
       connections to the Internet as described below.
     </para>
    </sect3>
-   <sect3 xml:id="untrusted_code">
+   <sect3 xml:id="untrusted-code">
     <title>Untrusted Code</title>
     <para>
       All code which is used to build content is considered
@@ -230,7 +230,7 @@
       the source server only.
     </para>
    </sect3>
-   <sect3 xml:id="frontend_background">
+   <sect3 xml:id="frontend-background">
     <title>&obs; Frontend Background Services</title>
     <para>
      &obs; frontend background services handle less time critical operations.
@@ -238,7 +238,7 @@
      trackers, sending notifications or long running jobs.
     </para>
    </sect3>
-   <sect3 xml:id="stage_server">
+   <sect3 xml:id="stage-server">
     <title>Stage Server</title>
     <para>
       The stage server is providing the public content of the &obs; backends.
@@ -246,7 +246,7 @@
       a mirror infrastructure.
     </para>
    </sect3>
-   <sect3 xml:id="cloud_uploader">
+   <sect3 xml:id="cloud-uploader">
     <title>Cloud Uploader</title>
     <para>
       The cloud uploader is uploading build results on user request. It reads
@@ -255,7 +255,7 @@
       This is an optional service.
     </para>
    </sect3>
-   <sect3 xml:id="source_service">
+   <sect3 xml:id="source-service">
     <title>Source Service Server</title>
     <para>
       The source service server is acting based on uploaded sources. The 
@@ -266,12 +266,12 @@
     </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="internal_zone">
+  <sect2 xml:id="internal-zone">
    <title>Internal Zone</title>
    <para>The internal zone is running service which are supposed to work
          without further external dependency.
    </para>
-   <sect3 xml:id="source_server">
+   <sect3 xml:id="source-server">
     <title>&obs; Source Server</title>
     <para>
       The source server coordinates changes to package and project configuration.
@@ -281,7 +281,7 @@
       There can only be a single source server per OBS install.
     </para>
    </sect3>
-   <sect3 xml:id="binary_server">
+   <sect3 xml:id="binary-server">
     <title>&obs; Binary Servers</title>
     <para>
       Binary Servers are hosting all content of build results. They 
@@ -289,7 +289,7 @@
       staging server.
     </para>
    </sect3>
-   <sect3 xml:id="external_dependencies">
+   <sect3 xml:id="external-dependencies">
     <title>External Dependencies</title>
     <para>
       The internal zone has no external dependency.
@@ -300,19 +300,19 @@
     </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="worker_zone">
+  <sect2 xml:id="worker-zone">
    <title>Worker Zone</title>
    <para>The &obs; workers are running in an own isolated network. 
          They access only source and binary servers from internal zone.
    </para>
   </sect2>
-  <sect2 xml:id="signing_server">
+  <sect2 xml:id="signing-server">
    <title>Signing Server</title>
    <para>The signing server is supposed to be the most isolated service.
          It is supposed to be stateless after initial setup.
          Avoid to enable any remote access.
    </para>
-  <figure xml:id="fig.obsbg.trust_zones">
+  <figure xml:id="fig-obsbg-trust-zones">
    <title>Trust Zones of &obs;</title>
    <mediaobject>
     <imageobject>

--- a/xml/obs_ag_security_concepts.xml
+++ b/xml/obs_ag_security_concepts.xml
@@ -18,11 +18,11 @@
         However, optional services to integrate remote resources exist as well. These resources
         are either mirrored and stored in revision control system or just cached.
         </para>
-  <sect2 xml:id="network-setup">
+  <sect2 xml:id="general-paradigm-network-setup">
    <title>Frontend</title>
    <para>The API and web interface frontends is the only part which must be accessible from
 	   public network. A SSL/TLS certificate is highly recommended.</para>
-   <sect3 xml:id="network-access">
+   <sect3 xml:id="general-paradigm-network-setup-network-access">
     <title>Access to Mirror Servers</title>
     <para>The following services require access to stage servers. These servers
           can be used to publish content without the need to make &obs; server parts
@@ -40,7 +40,7 @@
      </listitem>
     </itemizedlist>
    </sect3>
-   <sect3 xml:id="public-network-access">
+   <sect3 xml:id="general-paradigm-network-setup-public-network-access">
     <title>Access to the Public Network</title>
     <para>The following services may require access to the public network.</para>
     <itemizedlist>
@@ -67,14 +67,14 @@
      </listitem>
     </itemizedlist>
    </sect3>
-   <sect3 xml:id="worker-network">
+   <sect3 xml:id="general-paradigm-network-setup-worker-network">
     <title>Worker network</title>
     <para>It is recommended to run the &obs; workers in an isolated network. This is
           an additional security mechanism in case of a security breach on a worker.
           This network needs access to the source and repository servers of the &obs;
           backend, but nowhere else.</para>
    </sect3>
-   <sect3 xml:id="signd-network">
+   <sect3 xml:id="general-paradigm-network-setup-signd-network">
     <title>Signer network</title>
     <para>It is recommended to run the signd on an isolated host. The signer services
           need to stay on the &obs; backend servers, they are just used for scheduling
@@ -88,7 +88,7 @@
           backend server components (source server and publisher).</para>
    </sect3>
   </sect2>
-  <sect2 xml:id="build-env">
+  <sect2 xml:id="general-paradigm-build-env">
    <title>Build Environment</title>
    <para>The build environment is created by obsworker instances via the build script.
          Inside the build instances unverified and potentially harmful code is executed.
@@ -112,7 +112,7 @@
          source packages are rebuildable without root permissions.
          </para>
   </sect2>
-  <sect2 xml:id="source-revision-system">
+  <sect2 xml:id="general-paradigm-source-revision-system">
    <title>Source Revision System</title>
    <para>The source revision storage system is part of &obs;. The identification of sources
          still happens using MD5 sums for historic reasons. MD5 is considered to be still
@@ -126,7 +126,7 @@
          builds, but it should be avoided for base projects.
          </para>
   </sect2>
-  <sect2 xml:id="permission-handling">
+  <sect2 xml:id="general-paradigm-permission-handling">
    <title>Permission Handling</title>
    <para>Authorization for write operations is done via the maintainer role on package
          or project level. On project level the projects are organized in namespaces
@@ -136,7 +136,7 @@
          top level namespaces (for example, openSUSE: namespace in our reference instance).
    </para>
   </sect2>
-  <sect2 xml:id="signature-handling">
+  <sect2 xml:id="general-paradigm-signature-handling">
    <title>Signature Handling</title>
    <para>Signatures are used to proof the origin of a shipment independent of
           &obs; instance. Once the <systemitem>signd</systemitem> daemon has
@@ -187,11 +187,11 @@
         separated via network or virtualization mechanics.
   </para>
 
-  <sect2 xml:id="public-zone">
+  <sect2 xml:id="trust-zones-public-zone">
    <title>Public Zones</title>
    <para>Public zones are areas where any code under user control is running.
    </para>
-   <sect3 xml:id="external-network">
+   <sect3 xml:id="trust-zones-public-zone-external-network">
     <title>External Network</title>
     <para>
       This can be the public Internet if the &obs; instance is a public
@@ -201,7 +201,7 @@
       connections to the Internet as described below.
     </para>
    </sect3>
-   <sect3 xml:id="untrusted-code">
+   <sect3 xml:id="trust-zones-public-zone-untrusted-code">
     <title>Untrusted Code</title>
     <para>
       All code which is used to build content is considered
@@ -215,12 +215,12 @@
     </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="dmz">
+  <sect2 xml:id="trust-zones-dmz">
    <title>Demilitarized Zone (DMZ)</title>
    <para>The Demilitarized Zone contains services which interact with
          the public zone directly. 
    </para>
-   <sect3 xml:id="frontend">
+   <sect3 xml:id="trust-zones-dmz-frontend">
     <title>&obs; Frontend</title>
     <para>
       The frontend service is the only service which provides an open port.
@@ -230,7 +230,7 @@
       the source server only.
     </para>
    </sect3>
-   <sect3 xml:id="frontend-background">
+   <sect3 xml:id="trust-zones-dmz-frontend-background">
     <title>&obs; Frontend Background Services</title>
     <para>
      &obs; frontend background services handle less time critical operations.
@@ -238,7 +238,7 @@
      trackers, sending notifications or long running jobs.
     </para>
    </sect3>
-   <sect3 xml:id="stage-server">
+   <sect3 xml:id="trust-zones-dmz-stage-server">
     <title>Stage Server</title>
     <para>
       The stage server is providing the public content of the &obs; backends.
@@ -246,7 +246,7 @@
       a mirror infrastructure.
     </para>
    </sect3>
-   <sect3 xml:id="cloud-uploader">
+   <sect3 xml:id="trust-zones-dmz-cloud-uploader">
     <title>Cloud Uploader</title>
     <para>
       The cloud uploader is uploading build results on user request. It reads
@@ -255,7 +255,7 @@
       This is an optional service.
     </para>
    </sect3>
-   <sect3 xml:id="source-service">
+   <sect3 xml:id="trust-zones-dmz-source-service">
     <title>Source Service Server</title>
     <para>
       The source service server is acting based on uploaded sources. The 
@@ -266,12 +266,12 @@
     </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="internal-zone">
+  <sect2 xml:id="trust-zones-internal-zone">
    <title>Internal Zone</title>
    <para>The internal zone is running service which are supposed to work
          without further external dependency.
    </para>
-   <sect3 xml:id="source-server">
+   <sect3 xml:id="trust-zones-internal-zone-source-server">
     <title>&obs; Source Server</title>
     <para>
       The source server coordinates changes to package and project configuration.
@@ -281,7 +281,7 @@
       There can only be a single source server per OBS install.
     </para>
    </sect3>
-   <sect3 xml:id="binary-server">
+   <sect3 xml:id="trust-zones-internal-zone-binary-server">
     <title>&obs; Binary Servers</title>
     <para>
       Binary Servers are hosting all content of build results. They 
@@ -289,7 +289,7 @@
       staging server.
     </para>
    </sect3>
-   <sect3 xml:id="external-dependencies">
+   <sect3 xml:id="trust-zones-internal-zone-external-dependencies">
     <title>External Dependencies</title>
     <para>
       The internal zone has no external dependency.
@@ -300,19 +300,19 @@
     </para>
    </sect3>
   </sect2>
-  <sect2 xml:id="worker-zone">
+  <sect2 xml:id="trust-zones-worker-zone">
    <title>Worker Zone</title>
    <para>The &obs; workers are running in an own isolated network. 
          They access only source and binary servers from internal zone.
    </para>
   </sect2>
-  <sect2 xml:id="signing-server">
+  <sect2 xml:id="trust-zones-signing-server">
    <title>Signing Server</title>
    <para>The signing server is supposed to be the most isolated service.
          It is supposed to be stateless after initial setup.
          Avoid to enable any remote access.
    </para>
-  <figure xml:id="fig-obsbg-trust-zones">
+  <figure>
    <title>Trust Zones of &obs;</title>
    <mediaobject>
     <imageobject>

--- a/xml/obs_ag_source_publish.xml
+++ b/xml/obs_ag_source_publish.xml
@@ -6,7 +6,7 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="source_publish">
+ xml:id="source-publish">
  <title>Source Publisher</title>
  <para>The job of the source publish service is to publish all sources for 
 directly before published binaries. This will include the sources of repackaged
@@ -14,7 +14,7 @@ binaries. For example, the sources of RPMs which are used inside of product,
 appliance or container images. A prerequisite for this is that OBS has enabled
 content tracking for the used projects.</para>
 
- <sect2 xml:id="source_publish_configuration">
+ <sect2 xml:id="source-publish-configuration">
   <title>Configuring Source Publisher</title>
   <para>The source publishing can be configured via the file
     <emphasis>/usr/lib/obs/server/BSConfig.pm</emphasis>, where it can be 
@@ -26,7 +26,7 @@ content tracking for the used projects.</para>
   <screen language="perl">our $sourcepublish_filter = [ "openSUSE:.*", "SUSE:.*" ]; </screen>
  </sect2>
 
- <sect2 xml:id="source_publish_considerations">
+ <sect2 xml:id="source-publish-considerations">
   <title>Considerations</title>
   <para>The source publishing service is publishing the sources as they are hosted in &obs;. This
         means these are the unprocessed sources and the content is not identical to the
@@ -35,7 +35,7 @@ content tracking for the used projects.</para>
   <para>As a consequence hints like NoSource: tags in spec files are ignored. The only
         way to disable publishing for the user is to disable access or sourceaccess via
         the flags.</para>
-  <para>The filesystem structure is <emphasis>$project/$package/$srcmd5/</emphasis>. A  <xref linkend="obs.glos.disturl"/>
+  <para>The filesystem structure is <emphasis>$project/$package/$srcmd5/</emphasis>. A  <xref linkend="obs-glos-disturl"/>
         inside of binary builds can be used to find the right sources.</para>
   <para>&obs; will care for de-duplication on the rsync server. This must get implemented there.</para>
  </sect2>

--- a/xml/obs_ag_source_service.xml
+++ b/xml/obs_ag_source_service.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="sec.obs.source_service"
+<sect1 version="5.1" xml:id="sec-obs-source-service"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_ag_spider_identification.xml
+++ b/xml/obs_ag_spider_identification.xml
@@ -6,7 +6,7 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="_obs_spider_identification">
+ xml:id="obs-spider-identification">
  <title>Spider Identification</title>
  <para> OBS is hiding specific parts/pages of the application from search
   crawlers (DuckDuckGo, Google, etc.), mostly for performance reasons. Which

--- a/xml/obs_ag_tools.xml
+++ b/xml/obs_ag_tools.xml
@@ -3,9 +3,9 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="_tools">
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="tools">
  <title>Tools</title>
- <sect2 xml:id="_obs_admin">
+ <sect2 xml:id="tools-obs-admin">
   <title><command>obs_admin</command></title>
   <para>obs_admin is a command-line tool used on the back-end server(s) to manage
 running services, submit maintenance tasks, and debug problems.
@@ -142,7 +142,7 @@ Note: the --update-*-db calls are usually only needed when corrupt data has been
  --show-delta-store &lt;file&gt;
    Show delta store statistics</screen>
  </sect2>
- <sect2 xml:id="_osc">
+ <sect2 xml:id="tools-osc">
   <title>&osccmd;</title>
   <para>The <emphasis role="strong"><emphasis>osc</emphasis></emphasis> command-line client is mainly used by developers and packagers. But
 for some tasks, admin people also need this tool. It too has builtin help:
@@ -158,7 +158,7 @@ osc -A https://api.testobs.org</screen>
 give this file restrictive access rights, only read/write access for your user
 should be allowed. <emphasis role="strong">osc</emphasis> allows to store the password in other ways (in keyrings
 for example) and may use different methods for authentication like
-Kerberos see <xref linkend="_kerberos"/>
+Kerberos see <xref linkend="user-and-group-management-authentication-methods-kerberos"/>
    </para>
   </warning>
   <para>For admins the most important <emphasis role="strong"><emphasis>osc</emphasis></emphasis> subcommands are:</para>
@@ -174,12 +174,12 @@ API - to read and write online configuration data
 </para>
    </listitem>
   </itemizedlist>
-  <sect3 xml:id="_osc_meta_subcommand">
+  <sect3 xml:id="tools-osc-osc-meta-subcommand">
    <title><command>osc meta</command> Subcommand</title>
    <para>The <command>osc meta</command> subcommand is documented inside the "osc" tool itself. This documentation can be displayed by issuing the command:</para>
 <screen>osc meta --help</screen>
   </sect3>
-  <sect3 xml:id="_osc_api_subcommand">
+  <sect3 xml:id="tools-osc-osc-api-subcommand">
    <title><command>osc api</command> Subcommand</title>
    <para>The <command>osc api</command> subcommand is documented inside the "osc" tool itself. This documentation can be displayed by issuing the command:</para>
 <screen>osc api --help</screen>

--- a/xml/obs_ag_troubleshooting.xml
+++ b/xml/obs_ag_troubleshooting.xml
@@ -6,7 +6,7 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="obs.cha.troubleshooting">
+ xml:id="obs-cha-troubleshooting">
  <title>Troubleshooting</title>
  <info/>
 

--- a/xml/obs_ag_troubleshooting.xml
+++ b/xml/obs_ag_troubleshooting.xml
@@ -25,7 +25,7 @@
   description and so on. Most of them should not happen if the packager does
   test the build locally before committing it to the OBS. This type of problems
   is not covered by this chapter.</para>
- <sect1 xml:id="_general_hints">
+ <sect1 xml:id="general-hints">
   <title>General Hints</title>
   <para>If you detect unexpected behavior of the open build service, you
    should follow some rules to locate the problem:</para>
@@ -34,7 +34,7 @@
     <para> Consult the log files, for the back-end look at
       <emphasis>/srv/obs/log</emphasis> for the back-end log files and
       <emphasis>/srv/www/obs/api/log</emphasis> for the front-end log files.
-     See the Log files <xref linkend="_log_files"/> for more details.
+     See the Log files <xref linkend="log-files"/> for more details.
     </para>
    </listitem>
    <listitem>
@@ -64,7 +64,7 @@
    </listitem>
   </orderedlist>
  </sect1>
- <sect1 xml:id="_debug_frontend_problems">
+ <sect1 xml:id="debug-frontend-problems">
   <title>Debugging Front-end Problems</title>
   <para>If you get unexpected results from submitting commands with the
     <emphasis role="strong"><emphasis>osc</emphasis></emphasis> tool, you can

--- a/xml/obs_ag_troubleshooting.xml
+++ b/xml/obs_ag_troubleshooting.xml
@@ -27,7 +27,7 @@
   is not covered by this chapter.</para>
  <sect1 xml:id="general-hints">
   <title>General Hints</title>
-  <para>If you detect unexpected behavior of the open build service, you
+  <para>If you detect unexpected behavior of the OBS, you
    should follow some rules to locate the problem:</para>
   <orderedlist>
    <listitem>

--- a/xml/obs_ag_unpublish_hooks.xml
+++ b/xml/obs_ag_unpublish_hooks.xml
@@ -6,7 +6,7 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="_unpublisher_hooks">
+ xml:id="unpublisher-hooks">
  <title>Unpublisher Hooks</title>
  <para>The job of the publisher service is to publish the built packages
   and/or images by creating repositories that are made available through a web
@@ -16,7 +16,7 @@
   called <emphasis role="strong">unpublisher hooks</emphasis>. <emphasis
    role="strong">Unpublisher hooks</emphasis> are run before the <emphasis
    role="strong">publisher hooks</emphasis>.</para>
- <sect2 xml:id="_unpublisher_hooks_configuration">
+ <sect2 xml:id="unpublisher-hooks-unpublisher-hooks-configuration">
   <title>Configuring Unpublisher Hooks</title>
   <para>Hooks are configured via the configuration file
     <emphasis>/usr/lib/obs/server/BSConfig.pm</emphasis>, where one script per
@@ -107,9 +107,9 @@ our $unpublishedhook = {
      hook</emphasis>.</para>
   </note>
  </sect2>
- <sect2 xml:id="_example_unpublisher_scripts">
+ <sect2 xml:id="unpublisher-scripts-example-unpublisher-scripts">
   <title>Example Unpublisher Scripts</title>
-  <sect3 xml:id="_simple_unpublisher_hook">
+  <sect3 xml:id="unpublisher-scripts-example-unpublisher-scripts-simple-unpublisher-hook">
    <title>Simple Unpublisher Hook</title>
    <para>The following example script deletes all packages from the target
     directory that have been removed from the repository.</para>
@@ -137,7 +137,7 @@ done</screen>
     x86_64/icinga-1.13.3-1.3.x86_64.rpm           \
     x86_64/icinga-devel-1.13.3-1.3.x86_64.rpm</screen>
   </sect3>
-  <sect3 xml:id="_advanced_unpublisher_hook">
+  <sect3 xml:id="unpublisher-scripts-example-unpublisher-scripts-advanced-unpublisher-hook">
    <title>Advanced Unpublisher Hook</title>
    <para>The following example script reads the destination path from a
     parameter that is configured via the hook script:</para>

--- a/xml/obs_ag_user_management.xml
+++ b/xml/obs_ag_user_management.xml
@@ -6,7 +6,7 @@
 <sect1 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1"
- xml:id="_user_and_group_management">
+ xml:id="user-and-group-management">
  <title>Managing Users and Groups</title>
  <para>The OBS has an integrated user and group management with a role based
   access rights model. In every OBS instance, at least one user need to exist
@@ -14,7 +14,7 @@
   and instead of adding a list of users to a project/package role user can
   be added to a group and the group will be added to a project or package
   role.</para>
- <sect2 xml:id="_user_and_group_roles">
+ <sect2 xml:id="user-and-group-management-user-and-group-roles">
   <title>User and Group Roles</title>
   <para>The OBS role model has one global role: Admin, which can be granted
    to users. An OBS admin has access to all projects and packages via the API
@@ -96,7 +96,7 @@
    </tgroup>
   </table>
  </sect2>
- <sect2 xml:id="_standalone_user_and_group_database">
+ <sect2 xml:id="user-and-group-management-standalone-user-and-group-database">
   <title>Standalone User and Group Database</title>
   <para>OBS provides its own user database which can also store a password.
    The authentication to the API happens via HTTP BASIC AUTH. See the API
@@ -107,7 +107,7 @@
    confirmation is needed after registration before the user may
    login.</para>
  </sect2>
- <sect2 xml:id="_users_and_group_maintainers">
+ <sect2 xml:id="user-and-group-management-users-and-group-maintainers">
   <title>Users and Group Maintainers</title>
   <para>
     Administrators can create groups, add users to them, remove users from them and
@@ -116,7 +116,7 @@
   </para>
   <screen><command>osc api -d "&lt;group&gt;&lt;title&gt;&lt;group-title&gt;&lt;/title&gt;&lt;email&gt;&lt;group-email&gt;&lt;/email&gt;&lt;maintainer userid="&lt;user-name&gt;"/&gt;&lt;person&gt;&lt;person userid="&lt;user_name&gt;"/&gt;&lt;/person&gt;&lt;/group&gt;' -X PUT "/group/&lt;group-title&gt;" </command></screen>
  </sect2>
- <sect2 xml:id="_gravatar_for_groups">
+ <sect2 xml:id="user-and-group-management-gravatar-for-groups">
   <title>Gravatar for Groups</title>
   <para>In certain cases, it might be desirable to show a Gravatar for a group,
     similar to the users. In order to show a Gravatar, an email address is needed.
@@ -125,7 +125,7 @@
   </para>
   <screen><command>osc api -X POST "/group/&lt;group-title&gt;?cmd=set_email&amp;email=&lt;groups-email-address&gt;"</command></screen>
  </sect2>
- <sect2 xml:id="_proxy_mode">
+ <sect2 xml:id="user-and-group-management-proxy-mode">
   <title>Proxy Mode</title>
   <para>The proxy mode can be used for specially secured instances, where
    the OBS web server shall not get connected to the network directly. There
@@ -144,7 +144,7 @@
   </important>
   <para>With the proxy mode the user still need to be registered in the OBS
    and all OBS roles and user properties are managed inside the OBS.</para>
-  <sect3 xml:id="_obs_proxy_mode_configuration">
+  <sect3 xml:id="user-and-group-management-proxy-mode-obs-proxy-mode-configuration">
    <title>&obsa; Proxy Mode Configuration</title>
    <para>Currently the LDAP configuration is in the
      <emphasis>options.yml</emphasis> file.</para>
@@ -184,7 +184,7 @@
    </table>
   </sect3>
  </sect2>
- <sect2 xml:id="_ldap_active_directory">
+ <sect2 xml:id="user-and-group-management-ldap-active-directory">
   <title>LDAP/Active Directory</title>
   <note>
    <para>The LDAP support was considered experimental and not officially
@@ -231,7 +231,7 @@
      <emphasis>member</emphasis> attributes of the group are parsed and all
     current users which are in the local database become members.</para>
   </note>
-  <sect3 xml:id="_obs_ldap_configuration">
+  <sect3 xml:id="user-and-group-management-ldap-active-directory-obs-ldap-configuration">
    <title>OBS LDAP Configuration</title>
    <para>
     Currently the main OBS LDAP configuration is in the
@@ -741,9 +741,9 @@ ldap_group_objectclass_attr: group
 ldap_obs_admin_group: obsadmins</screen>
   </sect3>
  </sect2>
- <sect2 xml:id="_authentication_methods">
+ <sect2 xml:id="user-and-group-management-authentication-methods">
   <title>Authentication Methods</title>
-  <sect3 xml:id="_ldap_methods">
+  <sect3 xml:id="user-and-group-management-authentication-methods-ldap-methods">
    <title>LDAP Methods</title>
    <para>The LDAP mode has 2 methods to check
     authorization:</para>
@@ -764,7 +764,7 @@ ldap_obs_admin_group: obsadmins</screen>
      will not be available until you are bind with a privilege user.</para>
    </important>
   </sect3>
-  <sect3 xml:id="_kerberos">
+  <sect3 xml:id="user-and-group-management-authentication-methods-kerberos">
    <title>Kerberos</title>
    <para>In OBS you can use single sign on via Kerberos tickets.</para>
    <para>OBS Kerberos configuration resides in the

--- a/xml/obs_architecture.xml
+++ b/xml/obs_architecture.xml
@@ -16,7 +16,7 @@
   </abstract>
  </info>
 
- <sect1 xml:id="_overview_graph">
+ <sect1 xml:id="overview-graph">
   <title>Overview Graph</title>
   <para> &OBS; is not a monolithic server; it consists of multiple daemons
    that fulfill different tasks (see <xref linkend="fig.overview.simplified"/>). </para>
@@ -179,7 +179,7 @@
 
 <!-- <xi:include href="obs_ag_backend_components.xml"/>-->
 
- <sect1 xml:id="_communication_flow">
+ <sect1 xml:id="communication-flow">
   <title>Communication Flow</title>
   <para>
    The communication flow can be split into the following major parts:

--- a/xml/obs_architecture.xml
+++ b/xml/obs_architecture.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.architecture"
+<chapter version="5.1" xml:id="cha-obs-architecture"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -19,8 +19,8 @@
  <sect1 xml:id="overview-graph">
   <title>Overview Graph</title>
   <para> &OBS; is not a monolithic server; it consists of multiple daemons
-   that fulfill different tasks (see <xref linkend="fig.overview.simplified"/>). </para>
-  <figure xml:id="fig.overview.simplified">
+   that fulfill different tasks (see <xref linkend="fig-overview-simplified"/>). </para>
+  <figure xml:id="fig-overview-simplified">
    <title>Simplified OBS Component Overview</title>
    <mediaobject>
     <imageobject>
@@ -222,7 +222,7 @@
    other back-end components.
   </para>
 
-  <figure xml:id="fig_obs_communication">
+  <figure xml:id="fig-obs-communication">
    <title>OBS Communication (Simplified)</title>
    <mediaobject>
     <imageobject role="fo">
@@ -234,7 +234,7 @@
    </mediaobject>
   </figure>
   <para>
-   The figure <xref linkend="fig_obs_communication"/> shows the
+   The figure <xref linkend="fig-obs-communication"/> shows the
    communication flow between the &obsa; components if a package source
    (for example, a <filename>_service</filename> file) was updated:
   </para>

--- a/xml/obs_architecture.xml
+++ b/xml/obs_architecture.xml
@@ -19,8 +19,8 @@
  <sect1 xml:id="overview-graph">
   <title>Overview Graph</title>
   <para> &OBS; is not a monolithic server; it consists of multiple daemons
-   that fulfill different tasks (see <xref linkend="fig-overview-simplified"/>). </para>
-  <figure xml:id="fig-overview-simplified">
+   that fulfill different tasks:</para>
+  <figure>
    <title>Simplified OBS Component Overview</title>
    <mediaobject>
     <imageobject>
@@ -29,8 +29,7 @@
    </mediaobject>
   </figure>
   <para>
-  The OBS Back-end <!--is a collection of Perl applications that-->
-  manages the source files and build jobs of the OBS.
+  The OBS Backend manages the source files and build jobs of the OBS.
  </para>
 
  <variablelist>

--- a/xml/obs_authorization_token.xml
+++ b/xml/obs_authorization_token.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.authorization.token"
+<chapter version="5.1" xml:id="cha-obs-authorization-token"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_basic_workflow.xml
+++ b/xml/obs_basic_workflow.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.basicworkflow"
+<chapter version="5.1" xml:id="cha-obs-basicworkflow"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -18,7 +18,7 @@
   <remark>TBD</remark>
  </sect1>
 -->
- <sect1 xml:id="sec.obs.basicworkflow.setuphome">
+ <sect1 xml:id="sec-obs-basicworkflow-setuphome">
   <title>Setting Up Your Home Project</title>
   <remark>toms 2017-08-25: Suggestion by sknorr:
    generic section plus home project (cross refs only)
@@ -27,7 +27,7 @@
    This section shows how to set up your home project with the command line
    tool &osccmd;. For more
    information about setting up your home project with the Web UI, see
-   <xref linkend="sec.obsbg.uc.setuphome"/>.
+   <xref linkend="sec-obsbg-uc-setuphome"/>.
   </para>
   <para>
    This chapter is based on the following assumptions:
@@ -41,19 +41,19 @@
    </listitem>
    <listitem>
     <para>
-     You have installed &osccmd; as described in <xref linkend="sec.obs.osc.install"/>.
+     You have installed &osccmd; as described in <xref linkend="sec-obs-osc-install"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     You have configured &osccmd; as described in <xref linkend="sec.osc.firsttime"/>.
+     You have configured &osccmd; as described in <xref linkend="sec-osc-firsttime"/>.
     </para>
    </listitem>
   </itemizedlist>
 
   <procedure>
    <title>Setting Up Your Home Project</title>
-   <step xml:id="st.basicworkflow.setuphome.oscls">
+   <step xml:id="st-basicworkflow-setuphome-oscls">
     <para>
      Get a list of all available build targets of your &obsa; instance:
     </para>
@@ -66,7 +66,7 @@
      <uri>openSUSE:Tools</uri>, <uri>openSUSE:Templates</uri>.
     </para>
    </step>
-   <step xml:id="st.obs.metaprj">
+   <step xml:id="st-obs-metaprj">
     <para>
      Configure your build targets with:
     </para>
@@ -102,7 +102,7 @@
    <step>
     <para>
      Add more <tag>repository</tag> elements as needed.  Insert the information
-     from <xref linkend="st.basicworkflow.setuphome.oscls"/> into the
+     from <xref linkend="st-basicworkflow-setuphome-oscls"/> into the
      <tag class="attribute">project</tag> attribute.
     </para>
     <remark>
@@ -142,7 +142,7 @@
      is valid, &osccmd; will save it. Otherwise, it will show an error and
      prompt you whether to <guimenu>Try again?</guimenu>. In this case, press
      <keycap>n</keycap>. Your changes will be lost and you will need to start
-     from <xref linkend="st.obs.metaprj"/> again.
+     from <xref linkend="st-obs-metaprj"/> again.
     </para>
    </step>
   </procedure>
@@ -159,7 +159,7 @@
    assume that this project contains source code
    which you want to package for one or more &suse; (openSUSE) distributions.
    We assume the setup of your home project in your &obsa; instance is
-   already done. If not, refer to <xref linkend="sec.obs.basicworkflow.setuphome"/>.
+   already done. If not, refer to <xref linkend="sec-obs-basicworkflow-setuphome"/>.
   </para>
   <para>
    To create a package from the upstream project, do the following:
@@ -303,7 +303,7 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
 -->openSUSE_Tumbleweed x86_64 *.spec
     </screen>
     <para>
-     If you encounter problems, see <xref linkend="sec.obs.basicworkflow.builderrors"/>.
+     If you encounter problems, see <xref linkend="sec-obs-basicworkflow-builderrors"/>.
     </para>
    </step>
    <step>
@@ -343,7 +343,7 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
   </procedure>
  </sect1>
 
- <sect1 xml:id="sec.obs.basicworkflow.builderrors">
+ <sect1 xml:id="sec-obs-basicworkflow-builderrors">
   <title>Investigating the Local Build Process</title>
   <remark>toms 2017-08-22: https://en.opensuse.org/openSUSE:Build_Service_Tutorial#Correct_Errors_in_the_Local_Build_Process</remark>
   <para>
@@ -353,16 +353,16 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
   </para>
   <itemizedlist>
    <listitem>
-    <para><xref linkend="sec.obs.basicworkflow.builderrors.buildlog"/></para>
+    <para><xref linkend="sec-obs-basicworkflow-builderrors-buildlog"/></para>
    </listitem>
    <listitem>
-    <para><xref linkend="sec.obs.basicworkflow.builderrors.buildroot"/></para>
+    <para><xref linkend="sec-obs-basicworkflow-builderrors-buildroot"/></para>
    </listitem>
   </itemizedlist>
 
   <remark>toms 2017-08-22: Troubleshooting?</remark>
 
-  <sect2 xml:id="sec.obs.basicworkflow.builderrors.buildlog">
+  <sect2 xml:id="sec-obs-basicworkflow-builderrors-buildlog">
    <title>Build Log</title>
    <para>
     Each build produces a log file on &obsa;. This log file can be viewed by
@@ -412,7 +412,7 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
    </variablelist>
   </sect2>
 
-  <sect2 xml:id="sec.obs.basicworkflow.builderrors.buildroot">
+  <sect2 xml:id="sec-obs-basicworkflow-builderrors-buildroot">
    <title>Local Build Root Directory</title>
    <para>
     If you build a package locally and you get a build error, investigate
@@ -444,30 +444,30 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
    <para>
     The build root contains the following structure:
    </para>
-   <example xml:id="exa.workflow.buildroot">
+   <example xml:id="exa-workflow-buildroot">
     <title>Directory Structure of a Build Root (<filename>/var/tmp/build-root/</filename>)</title>
     <screen>/home/abuild/
 └── rpmbuild
-    ├── BUILD <co xml:id="co.workflow.buildroot.build"/>
-    ├── BUILDROOT  <co xml:id="co.workflow.buildroot.buildroot"/>
-    ├── OTHER  <co xml:id="co.workflow.buildroot.other"/>
-    ├── RPMS  <co xml:id="co.workflow.buildroot.rpms"/>
+    ├── BUILD <co xml:id="co-workflow-buildroot-build"/>
+    ├── BUILDROOT  <co xml:id="co-workflow-buildroot-buildroot"/>
+    ├── OTHER  <co xml:id="co-workflow-buildroot-other"/>
+    ├── RPMS  <co xml:id="co-workflow-buildroot-rpms"/>
     │   ├── i386
     │   ├── noarch
     │   └── x86_64
-    ├── SOURCES  <co xml:id="co.workflow.buildroot.sources"/>
-    ├── SPECS  <co xml:id="co.workflow.buildroot.specs"/>
-    └── SRPMS  <co xml:id="co.workflow.buildroot.srpms"/></screen>
+    ├── SOURCES  <co xml:id="co-workflow-buildroot-sources"/>
+    ├── SPECS  <co xml:id="co-workflow-buildroot-specs"/>
+    └── SRPMS  <co xml:id="co-workflow-buildroot-srpms"/></screen>
     <remark>toms 2017-08-22: https://rpm-packaging-guide.github.io/#rpm-packaging-workspace</remark>
     <calloutlist>
-     <callout arearefs="co.workflow.buildroot.build">
+     <callout arearefs="co-workflow-buildroot-build">
       <para>
        Contains directory named after the package name.
        In spec files, the name of the package directory is referenced
        using the <systemitem class="macro">%buildroot</systemitem> macro.
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.buildroot">
+     <callout arearefs="co-workflow-buildroot-buildroot">
       <para>
        If the build process was unable to create a package, this directory
        contains all files and directories which are installed in the target
@@ -479,12 +479,12 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
        emptied.
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.other">
+     <callout arearefs="co-workflow-buildroot-other">
       <para>
        Usually contains the file <filename>rpmlint.log</filename>.
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.rpms">
+     <callout arearefs="co-workflow-buildroot-rpms">
       <para>
        If the build was successful, stores binary RPMs into subdirectories of
        architecture
@@ -492,17 +492,17 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
        <filename>x86_64</filename>).
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.sources">
+     <callout arearefs="co-workflow-buildroot-sources">
       <para>
        All source files from the working copy will be copied here.
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.specs">
+     <callout arearefs="co-workflow-buildroot-specs">
       <para>
       <remark>toms 2017-08-22: empty?</remark>
       </para>
      </callout>
-     <callout arearefs="co.workflow.buildroot.srpms">
+     <callout arearefs="co-workflow-buildroot-srpms">
       <para>
        Stores source RPMs into this directory.
       </para>
@@ -534,24 +534,24 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
   <itemizedlist>
    <listitem>
     <para>
-     <xref linkend="sec.obs.basicworkflow.deps"/>
+     <xref linkend="sec-obs-basicworkflow-deps"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     <xref linkend="sec.obs.basicworkflow.layering"/>
+     <xref linkend="sec-obs-basicworkflow-layering"/>
      (<emphasis>layering</emphasis>)
     </para>
    </listitem>
    <listitem>
     <para>
-     <xref linkend="sec.obs.basicworkflow.reuse"/>
+     <xref linkend="sec-obs-basicworkflow-reuse"/>
      (<emphasis>linking</emphasis> and <emphasis>aggregating</emphasis>)
     </para>
    </listitem>
   </itemizedlist>
 
-  <sect2 xml:id="sec.obs.basicworkflow.deps">
+  <sect2 xml:id="sec-obs-basicworkflow-deps">
    <title>Adding Dependencies to Your Build Recipes</title>
    <remark>toms 2017-08-24: Should probably go into the concept part?</remark>
    <remark>toms 2017-08-24: should we explain hard and soft requirements?</remark>
@@ -561,7 +561,7 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
     requirements). Both belong to the header of the spec file<!-- (see <xref
      linkend=""/>)-->.
    </para>
-   <example xml:id="ex.obs.basicworkflow.excerpt">
+   <example xml:id="ex-obs-basicworkflow-excerpt">
     <title>Excerpt of Build and Installation Requirements</title>
     <screen>Name:             foo-example
 Version:          1.0.0
@@ -570,7 +570,7 @@ Requires:         zool >= 1.5.6</screen>
    </example>
    <remark>toms 2017-08-24: Version compare with zypper vcmp?</remark>
   </sect2>
-  <sect2 xml:id="sec.obs.basicworkflow.layering">
+  <sect2 xml:id="sec-obs-basicworkflow-layering">
    <title>Associating Other Repositories with Your Repository</title>
    <para>
     There is no need to duplicate the work of others. If you need a specific
@@ -597,7 +597,7 @@ Requires:         zool >= 1.5.6</screen>
      </para>
      <screen>&prompt.user;<command>osc</command> meta prj --edit &obshome1;</screen>
     </step>
-    <step xml:id="st.obs.basicworkflow.layering.repository">
+    <step xml:id="st-obs-basicworkflow-layering-repository">
      <para>
       Search for <tag>repository</tag> elements. For example, to allow usage
       packages from <uri>devel:languages:python</uri> in a
@@ -628,7 +628,7 @@ Requires:         zool >= 1.5.6</screen>
       </para>
      </note>
     </step>
-    <step xml:id="st.obs.basicworkflow.layering.path">
+    <step xml:id="st-obs-basicworkflow-layering-path">
      <para>
       Add more <tag>path</tag> elements under the same
       <tag>repository</tag> element.
@@ -636,14 +636,14 @@ Requires:         zool >= 1.5.6</screen>
     </step>
     <step>
      <para>
-      If necessary, repeat <xref linkend="st.obs.basicworkflow.layering.repository"/> and
-      <xref linkend="st.obs.basicworkflow.layering.path"/> to add <tag>path</tag>
+      If necessary, repeat <xref linkend="st-obs-basicworkflow-layering-repository"/> and
+      <xref linkend="st-obs-basicworkflow-layering-path"/> to add <tag>path</tag>
       elements to <tag>repository</tag> elements of other distributions or releases.
      </para>
     </step>
    </procedure>
   </sect2>
-  <sect2 xml:id="sec.obs.basicworkflow.reuse">
+  <sect2 xml:id="sec-obs-basicworkflow-reuse">
    <title>Reusing Packages in Your Project</title>
    <remark>toms 2017-08-30: This part and its subsections needs to be
    further discussed. "Aggregate" as a word doesn't really fit with the
@@ -657,7 +657,7 @@ Requires:         zool >= 1.5.6</screen>
    <remark>toms 2017-08-30: add a notes when NOT to use the two methods.
    </remark>
 
-   <sect3 xml:id="sec.obs.basicworkflow.reuse.aggregating" condition="tbs">
+   <sect3 xml:id="sec-obs-basicworkflow-reuse-aggregating" condition="tbs">
     <title>Aggregating a Package</title>
     <para>
      An <quote>aggregate</quote> package is a pointer to an &obsa; package.
@@ -706,7 +706,7 @@ Requires:         zool >= 1.5.6</screen>
      contains the <filename>_aggregate</filename> file.
     </para>
    </sect3>
-   <sect3 xml:id="sec.obs.basicworkflow.reuse.linking">
+   <sect3 xml:id="sec-obs-basicworkflow-reuse-linking">
     <title>Linking a Package</title>
     <para>
      A linked package is a clone of another package with

--- a/xml/obs_basic_workflow.xml
+++ b/xml/obs_basic_workflow.xml
@@ -764,7 +764,7 @@ At revision 1.</screen>
   </sect2>
  </sect1>
 
- <sect1 xml:id="sec.obs.basicworkflow.manage-group">
+ <sect1 xml:id="sec-obs-basicworkflow-manage-group">
   <title>Manage Group</title>
   <para>
     Users with Maintainer rights can add users to their group and remove users

--- a/xml/obs_basic_workflow.xml
+++ b/xml/obs_basic_workflow.xml
@@ -151,7 +151,7 @@
   </para>
  </sect1>
 
- <sect1 xml:id="sec.obs.basicworkflow.create-new">
+ <sect1 xml:id="sec-obs-basicworkflow-create-new">
   <title>Creating a New Package</title>
   <para>
    This section covers how to create packages for an arbitrary software project,
@@ -512,7 +512,7 @@ Fri Aug 23 08:42:42 UTC 2017 - &exampleuser_mail;</screen>
   </sect2>
  </sect1>
 
- <sect1 xml:id="sec.obs.basicworkflow.add-dependencies">
+ <sect1 xml:id="sec-obs-basicworkflow-add-dependencies">
   <title>Adding Dependencies to Your Project</title>
   <para>
    Software usually depends on other software: To run an application, you

--- a/xml/obs_best_practice_advanced.xml
+++ b/xml/obs_best_practice_advanced.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.advanced"
+<chapter version="5.1" xml:id="cha-obs-best-practices-advanced"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_basics.xml
+++ b/xml/obs_best_practice_basics.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.basics"
+<chapter version="5.1" xml:id="cha-obs-best-practices-basics"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_boot_strapping.xml
+++ b/xml/obs_best_practice_boot_strapping.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.bootstrapping"
+<chapter version="5.1" xml:id="cha-obs-best-practices-bootstrapping"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" os="opensuse;novell">

--- a/xml/obs_best_practice_distribution_setup.xml
+++ b/xml/obs_best_practice_distribution_setup.xml
@@ -12,7 +12,7 @@
  <section>
   <title>General Project Setup for a Maintained Distribution</title>
   <para>
-   <xref linkend="obs.glos.project_binary"/> are the
+   <xref linkend="obs-glos-project-binary"/> are the
   </para>
  </section>
  <section condition="tbd">

--- a/xml/obs_best_practice_distribution_setup.xml
+++ b/xml/obs_best_practice_distribution_setup.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha.obs.best-practices.distribution-setup"><title>Distribution Setup</title><info/>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha-obs-best-practices-distribution-setup"><title>Distribution Setup</title><info/>
  
  <para>
   This document describes ways to set up an entire distribution, including

--- a/xml/obs_best_practice_howto.xml
+++ b/xml/obs_best_practice_howto.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.howto"
+<chapter version="5.1" xml:id="cha-obs-best-practices-howto"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_best_practice_image_templates.xml
+++ b/xml/obs_best_practice_image_templates.xml
@@ -4,14 +4,14 @@
    %entities;
 ]>
 
-<sect1 version="5.1" xml:id="image_templates_how_to"
+<sect1 version="5.1" xml:id="image-templates-how-to"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Image Templates</title>
  &image_template_introduction_paragraph;
  <!--<xi:include href="obs_image_templates.xml"
-  xpointer="image_template_introduction_paragraph"/>-->
+  xpointer="image-template-introduction-paragraph"/>-->
  <para> How you can create your own image templates will be shown here. </para>
  <figure>
   <title>&obsa; Templates Page</title>
@@ -71,7 +71,7 @@
   <para> &kiwi; configurations usually consists of an xml configuration root
    tarball. </para>
   <!--<xi:include href="obs_image_templates.xml"
-   xpointer="image_template_icon_paragraph"/>-->
+   xpointer="image-template-icon-paragraph"/>-->
   &image_template_icon_paragraph;
   <para> For a full list of image descriptions and general information about
    building images with KIWI, see the <link

--- a/xml/obs_best_practice_integrate_scm_sources.xml
+++ b/xml/obs_best_practice_integrate_scm_sources.xml
@@ -4,7 +4,7 @@
     %entities;
 ]>
 
-<chapter version="5.1" xml:id="cha.obs.best-practices.scm_integration"
+<chapter version="5.1" xml:id="cha-obs-best-practices-scm-integration"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_kernel_build.xml
+++ b/xml/obs_best_practice_kernel_build.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha.obs.best-practices.kmp" os="opensuse;novell"><title>Building Kernel Modules</title><info/>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha-obs-best-practices-kmp" os="opensuse;novell"><title>Building Kernel Modules</title><info/>
 
    <para/>
    <remark>TBD: via Ann Davis?</remark>

--- a/xml/obs_best_practice_kiwi_editor.xml
+++ b/xml/obs_best_practice_kiwi_editor.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="kiwi_editor_how_to"
+<sect1 version="5.1" xml:id="kiwi-editor-how-to"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_local_setup.xml
+++ b/xml/obs_best_practice_local_setup.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.localsetup"
+<chapter version="5.1" xml:id="cha-obs-best-practices-localsetup"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" os="opensuse;novell">

--- a/xml/obs_best_practice_maintained_release.xml
+++ b/xml/obs_best_practice_maintained_release.xml
@@ -12,7 +12,7 @@
  <section>
   <title>General Project Setup for a Maintained Distribution</title>
   <para>
-   <xref linkend="obs.glos.project_binary"/> are the
+   <xref linkend="obs-glos-project-binary"/> are the
   </para>
  </section>
  <section>

--- a/xml/obs_best_practice_maintained_release.xml
+++ b/xml/obs_best_practice_maintained_release.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha.obs.best-practices.distribution-setup"><title>Distribution Setup</title><info/>
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha-obs-best-practices-distribution-setup"><title>Distribution Setup</title><info/>
  
  <para>
   This document describes ways to set up an entire distribution, including

--- a/xml/obs_best_practice_manage_group.xml
+++ b/xml/obs_best_practice_manage_group.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="manage_group"
+<sect1 version="5.1" xml:id="manage-group"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_osc_examples.xml
+++ b/xml/obs_best_practice_osc_examples.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.oscexamples"
+<chapter version="5.1" xml:id="cha-obs-best-practices-oscexamples"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" os="opensuse;novell">

--- a/xml/obs_best_practice_staging_workflow.xml
+++ b/xml/obs_best_practice_staging_workflow.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="staging_how_to"
+<sect1 version="5.1" xml:id="staging-how-to"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_best_practice_upstream.xml
+++ b/xml/obs_best_practice_upstream.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha.obs.best-practices.upstream" os="opensuse;novell">
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.1" xml:id="cha-obs-best-practices-upstream" os="opensuse;novell">
  <title>Publishing Upstream Binaries</title>
  <info/>
 
@@ -26,7 +26,7 @@
    </para>
    <para>
     More information about setting up your own private OBS instance can be
-    found in <xref linkend="cha.obs.best-practices.localsetup"/> .
+    found in <xref linkend="cha-obs-best-practices-localsetup"/> .
    </para>
   </sect2>
   <sect2>
@@ -152,10 +152,10 @@
    on newer websites. An example of download page can be following one
    <link xlink:href="http://software.opensuse.org/download.html?project=openSUSE:Tools&amp;package=osc"/>.
    You can see how it looks like in
-   <xref linkend="cha.obs.best-practices.upstream.download.screenshot"/>. It
+   <xref linkend="cha-obs-best-practices-upstream-download-screenshot"/>. It
    contains links to the packages and instructions how to install them.
   </para>
-  <figure xml:id="cha.obs.best-practices.upstream.download.screenshot">
+  <figure xml:id="cha-obs-best-practices-upstream-download-screenshot">
    <title>openSUSE download page for package from OBS</title>
    <mediaobject>
     <imageobject>
@@ -169,9 +169,9 @@
    any number of <literal>&amp;</literal>-separated parameters. But at least two of them -
    <emphasis>project</emphasis> and <emphasis>package</emphasis> - are
    required. All parameters with descriptions can be found in
-   <xref linkend="cha.obs.best-practices.upstream.download.params"/>.
+   <xref linkend="cha-obs-best-practices-upstream-download-params"/>.
   </para>
-  <table xml:id="cha.obs.best-practices.upstream.download.params">
+  <table xml:id="cha-obs-best-practices-upstream-download-params">
    <title>Parameters for Download Page</title>
    <tgroup cols="2" align="left">
     <thead>

--- a/xml/obs_best_practice_webui_usage.xml
+++ b/xml/obs_best_practice_webui_usage.xml
@@ -328,9 +328,8 @@ flood</screen>
    </figure>
    <para> The minimal set of fields you have to enter are architecture,
     repository type and the URL that provides the binary packages. Detailed
-    information about the data you can enter here you can find at the <link
-     xlink:href="https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.concepts.html#concept_dod"
-     >DoD concept section</link>. Press "Save" to create the repository. </para>
+    information about the data you can enter here can be found at
+    <xref linkend="concept-dod"/>. Press "Save" to create the repository. </para>
    <figure>
     <title>Download on Demand Repository Form</title>
     <mediaobject>

--- a/xml/obs_best_practice_webui_usage.xml
+++ b/xml/obs_best_practice_webui_usage.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.best-practices.webuiusage"
+<chapter version="5.1" xml:id="cha-obs-best-practices-webuiusage"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -212,7 +212,7 @@ flood</screen>
    <para> Wonderful, we've added a pointer to the sources! Now we need to add a
     repository, so the builder knows the target-distribution to build packages
     for. How to add a repository to a project is documented at <xref
-     linkend="cha.obs.best-practices.webuiusage.add-repository"/>. </para>
+     linkend="cha-obs-best-practices-webuiusage-add-repository"/>. </para>
   </sect2>
   <sect2>
    <title>Package Page, Build Log and Project Monitor Page</title>
@@ -286,13 +286,13 @@ flood</screen>
  <sect1>
   <title>Managing Repositories</title>
   <para> This section will show how you can manage your project's repositories. </para>
-  <sect2 xml:id="cha.obs.best-practices.webuiusage.add-repository">
+  <sect2 xml:id="cha-obs-best-practices-webuiusage-add-repository">
    <title>Adding a repository</title>
    <para> To add a repository to your project, click on "Add Repositories" on
     the project's repository tab. This will direct you to a list of possible
     distributions you can build packages for, see <xref
-     linkend="cha.obs.best-practices.webuiusage.add-repository.screenshot"/>. </para>
-   <figure xml:id="cha.obs.best-practices.webuiusage.add-repository.screenshot">
+     linkend="cha-obs-best-practices-webuiusage-add-repository-screenshot"/>. </para>
+   <figure xml:id="cha-obs-best-practices-webuiusage-add-repository-screenshot">
     <title>Adding a Repository to a Project</title>
     <mediaobject>
      <imageobject>

--- a/xml/obs_binary_tracking.xml
+++ b/xml/obs_binary_tracking.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.binary_tracking"
+<chapter version="5.1" xml:id="cha-obs-binary-tracking"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_build_config.xml
+++ b/xml/obs_build_config.xml
@@ -3,14 +3,14 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.prjconfig"
+<chapter version="5.1" xml:id="cha-obs-prjconfig"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Build Configuration</title>
  <info/>
 
- <sect1 xml:id="sec.prjconfig.about">
+ <sect1 xml:id="sec-prjconfig-about">
   <title>About the Build Configuration</title>
   <para>
    Each project has a <firstterm>build configuration</firstterm> which
@@ -93,7 +93,7 @@
   </itemizedlist>
  </sect1>
 
- <sect1 xml:id="sec.prjconfig.syntax">
+ <sect1 xml:id="sec-prjconfig-syntax">
   <title>Configuration File Syntax</title>
   <para>
    The syntax is basically the same as in RPM spec files.
@@ -128,7 +128,7 @@
    The following list contains a list of allowed keywords in the build
    configuration (prjconf):
   </para>
-  <variablelist xml:id="vl.prjconfig.keywords">
+  <variablelist xml:id="vl-prjconfig-keywords">
    <title>Available Keywords in Build Configuration</title>
    <!-- AssetsURL is not mentioned here as it has no effect in OBS -->
    <varlistentry>
@@ -958,7 +958,7 @@ Support: pax debbuild</screen>
   </variablelist>
  </sect1>
 
- <sect1 xml:id="sec.prjconfig.ccache">
+ <sect1 xml:id="sec-prjconfig-ccache">
   <title>Building with ccache or sccache</title>
   <para>
     The usage of ccache or sccache can be enabled for each package by
@@ -997,7 +997,7 @@ Support: pax debbuild</screen>
 
  </sect1>
 
- <sect1 xml:id="sec.prjconfig.macros">
+ <sect1 xml:id="sec-prjconfig-macros">
   <title>Macro Definitions in the Build Configuration</title>
   <para>
     You can use rpm macro definitions in the build configuration (prjconf) to improve
@@ -1056,7 +1056,7 @@ Support: pax debbuild</screen>
    </listitem>
   </itemizedlist>
 
-  <sect2 xml:id="sec.prjconfig.macros.define">
+  <sect2 xml:id="sec-prjconfig-macros-define">
    <title>Macros for the Build Configuration Only</title>
    <para>
      To specify macros for the building process, use the %define
@@ -1071,7 +1071,7 @@ Support: pax debbuild</screen>
     the build configuration.
    </para>
   </sect2>
-  <sect2 xml:id="sec.prjconfig.macros.macrosection">
+  <sect2 xml:id="sec-prjconfig-macros-macrosection">
    <title>Macros Used in Spec Files Only</title>
    <para>
     To define the values of macros used in spec files, `%define` is <emphasis

--- a/xml/obs_build_constraints.xml
+++ b/xml/obs_build_constraints.xml
@@ -57,7 +57,7 @@
    </sect3>
   </sect2>
  </sect1>
- <sect1 xml:id="_constraint_qualifiers">
+ <sect1 xml:id="constraint-qualifiers">
   <title>Constraint Qualifiers</title>
   <para> In general, build constraints are specified in terms of a qualifier
    and a value. The qualifier expresses "what" - the build worker parameter
@@ -76,7 +76,7 @@
    and <literal>unit=G</literal> means "the value is expressed in units of
    Gigabytes. </para>
   <para> For a full treatment of constraint syntax, see
-   <xref linkend="_constraint_syntax"/>. </para>
+   <xref linkend="constraint-syntax"/>. </para>
  </sect1>
  <sect1>
   <title>Constraint scope and precedence </title>
@@ -102,7 +102,7 @@
     defined in the project config by adding lines as so: </para>
    <screen>Constraint: &lt;QUALIFIER&gt; &lt;VALUE&gt;</screen>
    <para> The QUALIFIER syntax is the same as used in RPM spec files, documented
-    in <xref linkend="_constraint_syntax"/>. Within the project configuration,
+    in <xref linkend="constraint-syntax"/>. Within the project configuration,
     individual <literal>Constraint</literal> lines can be enclosed in guards to
     make a constraint apply only to certain architectures or repositories. For
     example:</para>
@@ -118,7 +118,7 @@ Constraint: hardware:disk:size unit=M 4000
      project itself, but also all projects that build against it.</para>
      </important>
    <para> For a full treatment of constraint syntax, see
-    <xref linkend="_constraint_syntax"/>. </para>
+    <xref linkend="constraint-syntax"/>. </para>
   </sect2>
   <sect2>
    <title>Package-scoped constraints</title>
@@ -144,7 +144,7 @@ Constraint: hardware:disk:size unit=M 4000
 &lt;/constraints&gt;</screen>
    <para> For details on constraint qualifiers and how to specify them
     in a <literal>_constraints</literal> file, see
-    <xref linkend="_constraint_syntax"/>. </para>
+    <xref linkend="constraint-syntax"/>. </para>
   </sect2>
   <sect2>
    <title>Build recipe-scoped constraints</title>
@@ -173,18 +173,18 @@ Constraint: hardware:disk:size unit=M 4000
     pool of compliant build workers down to a very low number, or even to zero.
     (A low number of compliant build workers means your build may not start for
     a long time, and no compliant workers at all will cause the build to fail.
-    See <xref linkend="_constraint_handling"/> for details.)
+    See <xref linkend="constraint-handling"/> for details.)
     </para></important>
    <important><para>
     By default, constraints applied to build workers regardless of
     architecture. However, you may only be interested in certain architectures
-    and not in others. See <xref linkend="_constraint_checking_with_osc"/>
+    and not in others. See <xref linkend="constraint-checking-with-osc"/>
     for how to get architecture-specific information on which workers satisfy
     your constraints.
     </para></important>
   </sect2>
  </sect1>
- <sect1 xml:id="_constraint_syntax">
+ <sect1 xml:id="constraint-syntax">
   <title>Constraint syntax</title>
   <para> This section describes the various constraint qualifiers and their
    syntax. </para>
@@ -425,7 +425,7 @@ Constraint: hardware:cpu:flag sse2</screen>
    </sect3>
   </sect2>
  </sect1>
- <sect1 xml:id="_constraint_handling">
+ <sect1 xml:id="constraint-handling">
   <title>Constraint Handling</title>
   <para> What happens when someone sets a constraint so high, that the OBS
    instance does not have even a single worker that meets it? What happens
@@ -470,7 +470,7 @@ no compliant workers (constraints mismatch hint: hardware:processors sandbox)
 Please adapt your constraints.</screen>
   </sect2>
  </sect1>
- <sect1 xml:id="_constraint_checking_with_osc">
+ <sect1 xml:id="constraint-checking-with-osc">
   <title>Checking Constraints with &osccmd;</title>
   <para> You can check the constraints of a project or package with the osc
    tool. You have to be in an &osccmd; working directory.</para>

--- a/xml/obs_build_constraints.xml
+++ b/xml/obs_build_constraints.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.build_constraints"
+<chapter version="5.1" xml:id="cha-obs-build-constraints"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_build_containers.xml
+++ b/xml/obs_build_containers.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.build_containers"
+<chapter version="5.1" xml:id="cha-obs-build-containers"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -84,7 +84,7 @@
     <listitem>
      <para>
       Flatpak packages can be built in the Open Build Service, see
-      <xref linkend="sec.pkgfmt.flatpak"/> for further details.
+      <xref linkend="sec-pkgfmt-flatpak"/> for further details.
      </para>
     </listitem>
    </varlistentry>
@@ -102,7 +102,7 @@
      <para>
       <link xlink:href="https://github.com/systemd/mkosi/">Mkosi</link> allows
       building images for rpm, arch, deb, and gentoo based distributions, see
-      <xref linkend="sec.pkgfmt.mkosi"/> for further details.
+      <xref linkend="sec-pkgfmt-mkosi"/> for further details.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/obs_build_containers.xml
+++ b/xml/obs_build_containers.xml
@@ -19,7 +19,7 @@
   libraries, executables and shared resource files.
  </para>
 
- <sect1 xml:id="_supported_formats">
+ <sect1 xml:id="supported-formats">
   <title>Supported Container Formats</title>
 
   <para>
@@ -117,7 +117,7 @@
    <para> </para>
    </sect2>-->
  </sect1>
- <sect1 xml:id="_container_registry">
+ <sect1 xml:id="container-registry">
   <title>Container Registry</title>
 
   <para>
@@ -184,7 +184,7 @@
      xlink:href="https://registry.opensuse.org/">registry.opensuse.org</link>
   </para>
  </sect1>
- <sect1 xml:id="_image_signatures">
+ <sect1 xml:id="image-signatures">
   <title>Container Image Signatures</title>
 
   <para>

--- a/xml/obs_build_preinstall.xml
+++ b/xml/obs_build_preinstall.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.build_preinstall"
+<chapter version="5.1" xml:id="cha-obs-build-preinstall"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_build_process.xml
+++ b/xml/obs_build_process.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.build_process"
+<chapter version="5.1" xml:id="cha-obs-build-process"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_concepts.xml
+++ b/xml/obs_concepts.xml
@@ -4,7 +4,7 @@
     %entities;
 ]>
 <!-- note: this is just a collection file atm, bigger parts should be moved to own files & chapters -->
-<chapter version="5.1" xml:id="cha.obs.concepts"
+<chapter version="5.1" xml:id="cha-obs-concepts"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_concepts_dod.xml
+++ b/xml/obs_concepts_dod.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="concept_dod"
+<sect1 version="5.1" xml:id="concept-dod"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_concepts_scm.xml
+++ b/xml/obs_concepts_scm.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<sect1 version="5.1" xml:id="concept_scm_integration"
+<sect1 version="5.1" xml:id="concept-scm-integration"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_cross_architecture_build.xml
+++ b/xml/obs_cross_architecture_build.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.cross_arch_build"
+<chapter version="5.1" xml:id="cha-obs-cross-arch-build"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_glossary.xml
+++ b/xml/obs_glossary.xml
@@ -10,21 +10,21 @@
   ******* Please post on the OBS mailing list your suggestion, if you ********
   ******* are unsure.                                                 ********
 -->
-<glossary version="5.1" xml:id="obs.glossary"
+<glossary version="5.1" xml:id="obs-glossary"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Glossary</title>
 
  <!-- ############## A ############## -->
- <glossentry xml:id="obs.glos.announcement" condition="tbd">
+ <glossentry xml:id="obs-glos-announcement" condition="tbd">
   <glossterm>Announcement</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.appimage">
+ <glossentry xml:id="obs-glos-appimage">
   <glossterm>&obs.ai;</glossterm>
   <!-- See https://en.opensuse.org/openSUSE:Build_Service_AppImage_builds -->
   <glossdef>
@@ -34,7 +34,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.apidoc">
+ <glossentry xml:id="obs-glos-apidoc">
   <glossterm>API</glossterm>
   <glossdef>
    <para>
@@ -48,7 +48,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.appliance">
+ <glossentry xml:id="obs-glos-appliance">
   <glossterm>Appliance</glossterm>
   <glossdef>
    <para>
@@ -58,22 +58,22 @@
     Appliances can be copied as-is onto a hard disk, an SSD, or started as a
     virtual machine (<emphasis>deployed</emphasis>).
    </para>
-   <glossseealso otherterm="obs.glos.os_image"/>
-   <glossseealso otherterm="obs.glos.image"/>
+   <glossseealso otherterm="obs-glos-os-image"/>
+   <glossseealso otherterm="obs-glos-image"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.archive">
+ <glossentry xml:id="obs-glos-archive">
   <glossterm baseform="Archive">Archive (Archive File)</glossterm>
   <glossdef>
    <para>
     An archive file contains a representation of usually multiple files and
     directories. Usually, archive files are also compressed. Archive
     files are the basis for binary packages
-    (<xref linkend="obs.glos.project_binary"/>).
+    (<xref linkend="obs-glos-project-binary"/>).
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.attribute">
+ <glossentry xml:id="obs-glos-attribute">
   <glossterm>Attribute</glossterm>
   <glossdef>
    <para>
@@ -85,7 +85,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## B ############## -->
- <glossentry xml:id="obs.glos.project_binary">
+ <glossentry xml:id="obs-glos-project-binary">
   <glossterm baseform="Binary Package">Binary Package (Binary)</glossterm>
   <glossdef>
    <para>
@@ -109,16 +109,16 @@
     human-readable like a script, usually does not matter). - sknorr,
     2017-08-30
    </remark>
-   <glossseealso otherterm="obs.glos.container"/>
-   <glossseealso otherterm="obs.glos.os_image"/>
-   <glossseealso otherterm="obs.gloss.source_package"/>
-   <glossseealso otherterm="obs.glos.deb"/>
-   <glossseealso otherterm="obs.glos.rpm"/>
-   <glossseealso otherterm="obs.glos.kiwi"/>
-   <glossseealso otherterm="obs.glos.archive"/>
+   <glossseealso otherterm="obs-glos-container"/>
+   <glossseealso otherterm="obs-glos-os-image"/>
+   <glossseealso otherterm="obs-gloss-source-package"/>
+   <glossseealso otherterm="obs-glos-deb"/>
+   <glossseealso otherterm="obs-glos-rpm"/>
+   <glossseealso otherterm="obs-glos-kiwi"/>
+   <glossseealso otherterm="obs-glos-archive"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.branch">
+ <glossentry xml:id="obs-glos-branch">
   <glossterm>Branch</glossterm>
   <glossdef>
    <para>
@@ -127,10 +127,10 @@
     repository. You can either <!-- update,? -->delete the branch or
     merge it into the original repository with a submit request.
    </para>
-   <glossseealso otherterm="obs.glos.submitrequest"/>
+   <glossseealso otherterm="obs-glos-submitrequest"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.bug">
+ <glossentry xml:id="obs-glos-bug">
   <glossterm>Bug</glossterm>
   <glossdef>
    <para>
@@ -138,7 +138,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.bugowner">
+ <glossentry xml:id="obs-glos-bugowner">
   <glossterm>Bugowner</glossterm>
   <glossdef>
    <!-- Helpful: https://en.opensuse.org/openSUSE:Package_maintainership_guide
@@ -149,17 +149,17 @@
     individual packages only. Users with this role can only read data but
     they are responsible for reacting to bug reports.
    </para>
-   <glossseealso otherterm="obs.glos.maintainer"/>
+   <glossseealso otherterm="obs-glos-maintainer"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.bugreporting" condition="tbd">
+ <glossentry xml:id="obs-glos-bugreporting" condition="tbd">
   <glossterm>Bug Reporting</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.build">
+ <glossentry xml:id="obs-glos-build">
   <glossterm>Build</glossterm>
   <glossdef>
    <para>
@@ -168,14 +168,14 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildlog">
+ <glossentry xml:id="obs-glos-buildlog">
   <glossterm>Build Log</glossterm>
   <glossdef>
    <para>Output of the build process of a certain package.</para>
-   <glossseealso otherterm="obs.glos.build"/>
+   <glossseealso otherterm="obs-glos-build"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildrecipe">
+ <glossentry xml:id="obs-glos-buildrecipe">
   <glossterm>Build Recipe</glossterm>
   <glossdef>
    <para>Generic term for a recipe file for creating a package.
@@ -185,11 +185,11 @@
     used and contains all the previous points. Debian-based systems use
     a <filename>debian</filename> directory which splits all the information.
    </para>
-   <glossseealso otherterm="obs.glos.spec"/>
-<!--   <glossseealso otherterm=""obs.glos.debianrulefile"/>-->
+   <glossseealso otherterm="obs-glos-spec"/>
+<!--   <glossseealso otherterm=""obs-glos-debianrulefile"/>-->
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildrequirement">
+ <glossentry xml:id="obs-glos-buildrequirement">
   <glossterm>Build Requirement</glossterm>
   <glossdef>
    <para>
@@ -198,18 +198,18 @@
     <remark>For example, a C++ program needs the C++ compiler included in the
     <package>gcc</package> package.</remark>
    </para>
-   <glossseealso otherterm="obs.glos.installrequirement"/>
-   <glossseealso otherterm="obs.glos.buildrecipe"/>
+   <glossseealso otherterm="obs-glos-installrequirement"/>
+   <glossseealso otherterm="obs-glos-buildrecipe"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildresult">
+ <glossentry xml:id="obs-glos-buildresult">
   <glossterm>Build Result</glossterm>
   <glossdef>
    <para>The current state of a package. Example of a build result could be
    succeeded, failed, blocked, etc.</para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildroot">
+ <glossentry xml:id="obs-glos-buildroot">
   <glossterm>Build Root</glossterm>
   <glossdef>
    <para>
@@ -217,10 +217,10 @@
     packages. By default, the build root is located in
     <filename>/var/tmp/build-root/<replaceable>BUILD_TARGET</replaceable></filename>.
    </para>
-   <glossseealso otherterm="obs.glos.buildtarget"/>
+   <glossseealso otherterm="obs-glos-buildtarget"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.buildtarget">
+ <glossentry xml:id="obs-glos-buildtarget">
   <glossterm>Build Target</glossterm>
   <glossdef>
    <para>
@@ -229,7 +229,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## C ############## -->
- <glossentry xml:id="obs.glos.changelog">
+ <glossentry xml:id="obs-glos-changelog">
   <glossterm>Changelog</glossterm>
   <glossdef>
    <para>
@@ -237,10 +237,10 @@
     can contain information about version updates, bug and security fixes,
     incompatible changes, or changes related to the distribution.
    </para>
-   <glossseealso otherterm="obs.glos.changesfile"/>
+   <glossseealso otherterm="obs-glos-changesfile"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.changesfile">
+ <glossentry xml:id="obs-glos-changesfile">
   <glossterm baseform="changesfile"><filename class="extension"
    >.changes</filename> File</glossterm>
   <glossdef>
@@ -248,10 +248,10 @@
     In &obsa;, a file with the file extension <filename class="extension"
      >.changes</filename> to store changelog information.
    </para>
-   <glossseealso otherterm="obs.glos.changelog"/>
+   <glossseealso otherterm="obs-glos-changelog"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.commit">
+ <glossentry xml:id="obs-glos-commit">
   <glossterm>Commit</glossterm>
   <glossdef>
    <para>
@@ -259,10 +259,10 @@
     the author, the date and time, a commit checksum, an optional request number,
     and a log message.
    </para>
-   <glossseealso otherterm="obs.glos.revision"/>
+   <glossseealso otherterm="obs-glos-revision"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.container">
+ <glossentry xml:id="obs-glos-container">
   <glossterm>Container</glossterm>
   <glossdef>
    <para>
@@ -275,25 +275,25 @@
     system. Unlike binary packages, containers are deployed and not installed.
     Formats of containers include &appimg;, &docker;, &snap;, and &flatpak;.
    </para>
-   <glossseealso otherterm="obs.glos.project_binary"/>
-   <glossseealso otherterm="obs.glos.os_image"/>
-   <glossseealso otherterm="obs.glos.image"/>
+   <glossseealso otherterm="obs-glos-project-binary"/>
+   <glossseealso otherterm="obs-glos-os-image"/>
+   <glossseealso otherterm="obs-glos-image"/>
    <!-- glosseealso docker/appimage/snap/flatpak etc. -->
   </glossdef>
  </glossentry>
 
  <!-- ############## D ############## -->
- <glossentry xml:id="obs.glos.deb">
+ <glossentry xml:id="obs-glos-deb">
   <glossterm>Deb</glossterm>
   <glossdef>
    <para>
     A package format created and used by the Debian distribution.
    </para>
-   <glossseealso otherterm="obs.glos.package"/>
-   <glossseealso otherterm="obs.glos.rpm"/>
+   <glossseealso otherterm="obs-glos-package"/>
+   <glossseealso otherterm="obs-glos-rpm"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.moderation_decision">
+ <glossentry xml:id="obs-glos-moderation-decision">
   <glossterm>Decision</glossterm>
   <glossdef>
    <para>
@@ -302,18 +302,18 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.description" condition="tbd">
+ <glossentry xml:id="obs-glos-description" condition="tbd">
   <glossterm>Description</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.dependency">
+ <glossentry xml:id="obs-glos-dependency">
   <glossterm>Dependency</glossterm>
-  <glosssee otherterm="obs.glos.requirement"/>
+  <glosssee otherterm="obs-glos-requirement"/>
  </glossentry>
- <glossentry xml:id="obs.glos.develproject">
+ <glossentry xml:id="obs-glos-develproject">
   <glossterm>Devel Project</glossterm>
   <glossdef>
    <para>
@@ -321,11 +321,11 @@
     the devel project <uri>devel:languages:python</uri> stores all packages
     related to the Python programming language.
    </para>
-   <glossseealso otherterm="obs.glos.homeproject"/>
-   <glossseealso otherterm="obs.glos.project"/>
+   <glossseealso otherterm="obs-glos-homeproject"/>
+   <glossseealso otherterm="obs-glos-project"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.docker">
+ <glossentry xml:id="obs-glos-docker">
   <glossterm>Docker</glossterm>
   <glossdef>
    <para>
@@ -333,10 +333,10 @@
     Docker is a lightweight virtualization solution to run multiple virtual
     units (containers) simultaneously on a single control host.
    </para>
-   <glossseealso otherterm="obs.glos.container"/>
+   <glossseealso otherterm="obs-glos-container"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.downloadrepository">
+ <glossentry xml:id="obs-glos-downloadrepository">
   <glossterm>Download Repository</glossterm>
   <glossdef>
    <para>
@@ -348,11 +348,11 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.diff">
+ <glossentry xml:id="obs-glos-diff">
   <glossterm>Diff</glossterm>
-  <glosssee otherterm="obs.glos.patch"/>
+  <glosssee otherterm="obs-glos-patch"/>
  </glossentry>
- <glossentry xml:id="obs.glos.disturl">
+ <glossentry xml:id="obs-glos-disturl">
   <glossterm>DISTURL</glossterm>
   <glossdef>
    <para>
@@ -384,7 +384,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## E ############## -->
- <glossentry xml:id="obs.glos.eula">
+ <glossentry xml:id="obs-glos-eula">
   <glossterm>EULA</glossterm>
   <glossdef>
    <para>
@@ -395,11 +395,11 @@
   </glossdef>
  </glossentry>
  <!-- ############## F ############## -->
- <glossentry xml:id="obs.glos.fix">
+ <glossentry xml:id="obs-glos-fix">
   <glossterm>Fix</glossterm>
-  <glosssee otherterm="obs.glos.patch"/>
+  <glosssee otherterm="obs-glos-patch"/>
  </glossentry>
- <glossentry xml:id="obs.glos.flag">
+ <glossentry xml:id="obs-glos-flag">
   <glossterm>Flags</glossterm>
   <glossdef>
    <para>
@@ -409,15 +409,15 @@
   </glossdef>
  </glossentry>
  <!-- ############## G ############## -->
- <glossentry xml:id="obs.glos.ga_project">
+ <glossentry xml:id="obs-glos-ga-project">
   <glossterm>GA Project</glossterm>
   <glossdef>
    <para> The GA (general availability) project builds an initial release of a product. It gets frozen
     after releasing the product. All further updates get released via the <xref
-     linkend="obs.glos.update_project"/> of this project. </para>
+     linkend="obs-glos-update-project"/> of this project. </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.gpgkey">
+ <glossentry xml:id="obs-glos-gpgkey">
   <glossterm>GPG Key</glossterm>
   <glossdef>
    <para>
@@ -427,27 +427,27 @@
   </glossdef>
  </glossentry>
  <!-- ############## H ############## -->
- <glossentry xml:id="obs.glos.homeproject">
+ <glossentry xml:id="obs-glos-homeproject">
   <glossterm>Home Project</glossterm>
   <glossdef>
    <para>
     Working area in OBS for uploading and building packages. Each
     home project starts with <uri>home:<replaceable>USERNAME</replaceable></uri>.
    </para>
-   <glossseealso otherterm="obs.glos.project"/>
+   <glossseealso otherterm="obs-glos-project"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.homerepository" condition="tbd">
+ <glossentry xml:id="obs-glos-homerepository" condition="tbd">
   <glossterm>Home Repository</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
-   <glossseealso otherterm="obs.glos.project"/>
-   <glossseealso otherterm="obs.glos.repository"/>
+   <glossseealso otherterm="obs-glos-project"/>
+   <glossseealso otherterm="obs-glos-repository"/>
   </glossdef>
  </glossentry>
  <!-- ############## I ############## -->
- <glossentry xml:id="obs.glos.image">
+ <glossentry xml:id="obs-glos-image">
   <glossterm baseform="Image">Image (Image File)</glossterm>
   <glossdef>
    <para>
@@ -456,12 +456,12 @@
     multiple types of image:
    </para>
     <simplelist type="inline">
-     <member><xref linkend="obs.glos.os_image"/></member>
-     <member><xref linkend="obs.glos.container"/></member>
+     <member><xref linkend="obs-glos-os-image"/></member>
+     <member><xref linkend="obs-glos-container"/></member>
     </simplelist>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.imagedescription">
+ <glossentry xml:id="obs-glos-imagedescription">
   <glossterm>Image Description</glossterm>
   <glossdef>
    <para>
@@ -470,10 +470,10 @@
     <filename class="extension">*.kiwi</filename>), scripts, or configuration data to
     customize certain parts of the &kiwi; build process.
    </para>
-   <glossseealso otherterm="obs.glos.kiwi"/>
+   <glossseealso otherterm="obs-glos-kiwi"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.incident">
+ <glossentry xml:id="obs-glos-incident">
   <glossterm>Incident</glossterm>
   <glossdef>
    <para> Describes a specific problem and the
@@ -482,7 +482,7 @@
     maintenance incident project and the update get built here. </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.installrequirement">
+ <glossentry xml:id="obs-glos-installrequirement">
   <glossterm>Installation Requirement</glossterm>
   <glossdef>
    <para>
@@ -491,7 +491,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## K ############## -->
- <glossentry xml:id="obs.glos.kiwi">
+ <glossentry xml:id="obs-glos-kiwi">
   <glossterm>&kiwi;</glossterm>
   <glossdef>
    <para>
@@ -499,31 +499,31 @@
     create images for Linux supported hardware platforms or for virtualization
     systems.
    </para>
-   <glossseealso otherterm="obs.glos.image"/>
+   <glossseealso otherterm="obs-glos-image"/>
   </glossdef>
  </glossentry>
  <!-- ############## L ############## -->
- <glossentry xml:id="obs.glos.license">
+ <glossentry xml:id="obs-glos-license">
   <glossterm>License</glossterm>
   <glossdef>
    <para>
     Written contract to specify permissions for use and distribution of software.
    </para>
-   <glossseealso otherterm="obs.glos.project"/>
+   <glossseealso otherterm="obs-glos-project"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.link">
+ <glossentry xml:id="obs-glos-link">
   <glossterm>Link</glossterm>
   <glossdef>
    <para>
     A concept that defines a relationship between a source and a
     target repository.
    </para>
-   <glossseealso otherterm="obs.glos.project"/>
+   <glossseealso otherterm="obs-glos-project"/>
   </glossdef>
  </glossentry>
  <!-- ############## M ############## -->
- <glossentry xml:id="obs.glos.maintainer">
+ <glossentry xml:id="obs-glos-maintainer">
   <glossterm>Maintainer</glossterm>
   <glossdef>
    <para>
@@ -532,26 +532,26 @@
     add, modify, and remove packages and subprojects, accept submit requests,
     and change metadata.
    </para>
-   <glossseealso otherterm="obs.glos.bugowner"/>
+   <glossseealso otherterm="obs-glos-bugowner"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.maintenance_project" vendor="suse">
+ <glossentry xml:id="obs-glos-maintenance-project" vendor="suse">
   <glossterm>Maintenance Project</glossterm>
   <glossdef>
    <para> A project without sources and binaries,
     defined by the maintenance team. Incidents are created as sub projects
     of this project. </para>
-   <glossseealso otherterm="obs.glos.incident"/>
+   <glossseealso otherterm="obs-glos-incident"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.maintenance_request" condition="tbd">
+ <glossentry xml:id="obs-glos-maintenance-request" condition="tbd">
   <glossterm>Maintenance Request</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.metadata" condition="tbd">
+ <glossentry xml:id="obs-glos-metadata" condition="tbd">
   <glossterm>Metadata</glossterm>
   <glossdef>
    <para/>
@@ -559,7 +559,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## O ############## -->
- <glossentry xml:id="obs.glos.obs_package">
+ <glossentry xml:id="obs-glos-obs-package">
   <glossterm>&obsa; Package</glossterm>
   <glossdef>
    <para>
@@ -583,7 +583,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.obs" sortas="Open Build Service">
+ <glossentry xml:id="obs-glos-obs" sortas="Open Build Service">
   <glossterm baseform="&obs;">&OBS;</glossterm>
   <glossdef>
    <para>
@@ -597,15 +597,15 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.build.o.o">
+ <glossentry xml:id="obs-glos-build-o-o">
   <glossterm>&osbs;</glossterm>
   <glossdef>
    <para> A specific Web service instance of <xref
-     linkend="obs.glos.obs"/> from the &opensuse; project at
+     linkend="obs-glos-obs"/> from the &opensuse; project at
     <link xlink:href="http://build.opensuse.org"/>. </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.osc">
+ <glossentry xml:id="obs-glos-osc">
   <glossterm>&osccmd;</glossterm>
   <glossdef>
    <para>
@@ -613,12 +613,12 @@
     stands for <emphasis>openSUSE commander</emphasis>. &osccmd; works
     similarly to SVN or Git.
    </para>
-   <glossseealso otherterm="obs.glos.obs"/>
+   <glossseealso otherterm="obs-glos-obs"/>
    <glossseealso><link xlink:href="https://github.com/openSUSE/osc"
    /></glossseealso>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.os_image">
+ <glossentry xml:id="obs-glos-os-image">
   <glossterm>Operating System Image</glossterm>
   <glossdef>
    <para>
@@ -627,20 +627,20 @@
     Depending on their purpose, operating system images are classified into:
    </para>
     <simplelist type="inline">
-     <member><xref linkend="obs.glos.product_image"/></member>
-     <member><xref linkend="obs.glos.appliance"/></member>
-     <member><xref linkend="obs.glos.vm_image"/></member>
+     <member><xref linkend="obs-glos-product-image"/></member>
+     <member><xref linkend="obs-glos-appliance"/></member>
+     <member><xref linkend="obs-glos-vm-image"/></member>
     </simplelist>
    <para>
     Formats of operating system images include ISO, Virtual Disk, and PXE Root
     File System.
    </para>
-   <glossseealso otherterm="obs.glos.project_binary"/>
-   <glossseealso otherterm="obs.glos.image"/>
-   <glossseealso otherterm="obs.glos.kiwi"/>
+   <glossseealso otherterm="obs-glos-project-binary"/>
+   <glossseealso otherterm="obs-glos-image"/>
+   <glossseealso otherterm="obs-glos-kiwi"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.overlay_file">
+ <glossentry xml:id="obs-glos-overlay-file">
   <glossterm>Overlay File</glossterm>
   <glossdef>
    <para>
@@ -652,31 +652,31 @@
     system (overlaid) of the appliance root. This includes
     permissions and attributes as a supplement.
    </para>
-   <glossseealso otherterm="obs.glos.appliance"/>
-   <glossseealso otherterm="obs.glos.kiwi"/>
-   <!--   <glossseealso otherterm="obs.glos.imagedescription"/>-->
+   <glossseealso otherterm="obs-glos-appliance"/>
+   <glossseealso otherterm="obs-glos-kiwi"/>
+   <!--   <glossseealso otherterm="obs-glos-imagedescription"/>-->
   </glossdef>
  </glossentry>
  <!-- ############## P ############## -->
- <glossentry xml:id="obs.glos.package">
+ <glossentry xml:id="obs-glos-package">
   <glossterm>Package</glossterm>
   <glossdef>
    <para>
     &obsa; handles very different types of software package:
    </para>
     <simplelist type="inline">
-     <member><xref linkend="obs.gloss.source_package"/></member>
-     <member><xref linkend="obs.glos.obs_package"/></member>
-     <member><xref linkend="obs.glos.project_binary"/></member>
+     <member><xref linkend="obs-gloss-source-package"/></member>
+     <member><xref linkend="obs-glos-obs-package"/></member>
+     <member><xref linkend="obs-glos-project-binary"/></member>
     </simplelist>
-   <glossseealso otherterm="obs.glos.container"/>
+   <glossseealso otherterm="obs-glos-container"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.packagerequirement">
+ <glossentry xml:id="obs-glos-packagerequirement">
   <glossterm>Package Requirement</glossterm>
-  <glosssee otherterm="obs.glos.requirement"/>
+  <glosssee otherterm="obs-glos-requirement"/>
  </glossentry>
- <glossentry xml:id="obs.glos.packagerepository">
+ <glossentry xml:id="obs-glos-packagerepository">
   <glossterm>Package Repository</glossterm>
   <glossdef>
    <para>A place where installable packages are available. This can
@@ -691,16 +691,16 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.patch">
+ <glossentry xml:id="obs-glos-patch">
   <glossterm>Patch</glossterm>
   <glossdef>
    <para>
     Textual differences between two versions of a file.
    </para>
-   <glossseealso otherterm="obs.glos.patchfile"/>
+   <glossseealso otherterm="obs-glos-patchfile"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.patchfile">
+ <glossentry xml:id="obs-glos-patchfile">
   <glossterm>Patch File</glossterm>
   <glossdef>
    <para>
@@ -708,17 +708,17 @@
      class="extension">.diff</filename> or <filename class="extension"
       >.patch</filename>.
    </para>
-   <glossseealso otherterm="obs.glos.patch"/>
+   <glossseealso otherterm="obs-glos-patch"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.patchinfo" condition="tbd">
+ <glossentry xml:id="obs-glos-patchinfo" condition="tbd">
   <glossterm>Patchinfo</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.product_image">
+ <glossentry xml:id="obs-glos-product-image">
   <glossterm>Product Image</glossterm>
   <glossdef>
    <para>
@@ -729,11 +729,11 @@
     Live images are a special case of operating system images. They can be
     run directly a USB disk or DVD and are often but not always installable.
    </para>
-   <glossseealso otherterm="obs.glos.os_image"/>
-   <glossseealso otherterm="obs.glos.image"/>
+   <glossseealso otherterm="obs-glos-os-image"/>
+   <glossseealso otherterm="obs-glos-image"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.project">
+ <glossentry xml:id="obs-glos-project">
   <glossterm>Project</glossterm>
   <glossdef>
    <para>
@@ -742,7 +742,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.projectconfiguration">
+ <glossentry xml:id="obs-glos-projectconfiguration">
   <glossterm>Project Configuration</glossterm>
   <glossdef>
    <para>
@@ -750,21 +750,21 @@
     on or off certain features during the build or to handle circular
     dependencies.
    </para>
-   <glossseealso otherterm="obs.glos.project"/>
+   <glossseealso otherterm="obs-glos-project"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.publishing">
+ <glossentry xml:id="obs-glos-publishing">
   <glossterm>Publishing</glossterm>
   <glossdef>
    <para>
     Finished process when a package is successfully built and available in the
     download repository.
    </para>
-   <glossseealso otherterm="obs.glos.downloadrepository"/>
+   <glossseealso otherterm="obs-glos-downloadrepository"/>
   </glossdef>
  </glossentry>
  <!-- ############## R ############## -->
- <glossentry xml:id="obs.glos.release_project">
+ <glossentry xml:id="obs-glos-release-project">
   <glossterm>Release Project</glossterm>
   <glossdef>
    <para> A release project is hosting a release repository which is not
@@ -773,17 +773,17 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.repository">
+ <glossentry xml:id="obs-glos-repository">
   <glossterm>Repository</glossterm>
   <glossdef>
    <para>
      A distribution-specific area that holds dependencies required for
      building a package.
    </para>
-   <glossseealso otherterm="obs.glos.downloadrepository"/>
+   <glossseealso otherterm="obs-glos-downloadrepository"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.repofile">
+ <glossentry xml:id="obs-glos-repofile">
   <glossterm>Repo File</glossterm>
   <glossdef>
    <para>
@@ -792,56 +792,56 @@
     name of the repository, the repository type, and references to the download
     repository and the GPG key.
    </para>
-   <glossseealso otherterm="obs.glos.downloadrepository"/>
+   <glossseealso otherterm="obs-glos-downloadrepository"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.request" condition="tbd">
+ <glossentry xml:id="obs-glos-request" condition="tbd">
   <glossterm>Request</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.requirement">
+ <glossentry xml:id="obs-glos-requirement">
   <glossterm>Requirement</glossterm>
   <glossdef>
    <para>
     In the &obsa; context, package requirements that are needed to
     create, build, or install a package.
    </para>
-   <glossseealso otherterm="obs.glos.buildrequirement"/>
-   <glossseealso otherterm="obs.glos.installrequirement"/>
+   <glossseealso otherterm="obs-glos-buildrequirement"/>
+   <glossseealso otherterm="obs-glos-installrequirement"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.revision">
+ <glossentry xml:id="obs-glos-revision">
   <glossterm>Revision</glossterm>
   <glossdef>
    <para>A unique numeric identifier of a commit.</para>
-   <glossseealso otherterm="obs.glos.commit"/>
+   <glossseealso otherterm="obs-glos-commit"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.rpm">
+ <glossentry xml:id="obs-glos-rpm">
   <glossterm>RPM</glossterm>
   <glossdef>
    <para>
     A package format. It stands for recursive acronym RPM Package Manager.
     Mainly used by &suse;, Red Hat, u.a.
    </para>
-   <glossseealso otherterm="obs.glos.deb"/>
-   <glossseealso otherterm="obs.glos.package"/>
+   <glossseealso otherterm="obs-glos-deb"/>
+   <glossseealso otherterm="obs-glos-package"/>
   </glossdef>
  </glossentry>
  <!-- ############## S ############## -->
- <glossentry xml:id="obs.glos.sandbox">
+ <glossentry xml:id="obs-glos-sandbox">
   <glossterm>Sandbox</glossterm>
   <glossdef>
    <para>Isolated region of a host system which runs either a virtual machine
     or a change root environment.
    </para>
-   <glossseealso otherterm="obs.glos.buildroot"/>
+   <glossseealso otherterm="obs-glos-buildroot"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.servicefile">
+ <glossentry xml:id="obs-glos-servicefile">
   <glossterm>Service File</glossterm>
   <glossdef>
    <para>
@@ -851,7 +851,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.spec">
+ <glossentry xml:id="obs-glos-spec">
   <glossterm>Spec File</glossterm>
   <glossdef>
    <para>
@@ -859,32 +859,32 @@
     a general package description and dependencies required for
     building and installing the package.
    </para>
-   <glossseealso otherterm="obs.glos.buildrecipe"/>
-   <glossseealso otherterm="obs.glos.patch"/>
-   <glossseealso otherterm="obs.glos.source"/>
+   <glossseealso otherterm="obs-glos-buildrecipe"/>
+   <glossseealso otherterm="obs-glos-patch"/>
+   <glossseealso otherterm="obs-glos-source"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.statusmonitor" condition="tbd">
+ <glossentry xml:id="obs-glos-statusmonitor" condition="tbd">
   <glossterm>Status Monitor</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.source">
+ <glossentry xml:id="obs-glos-source">
   <glossterm>Source</glossterm>
   <glossdef>
    <para>
     Original form, mostly written in a computer language.
    </para>
-   <glossseealso otherterm="obs.glos.package"/>
+   <glossseealso otherterm="obs-glos-package"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.sourcelink">
+ <glossentry xml:id="obs-glos-sourcelink">
   <glossterm>Source Link</glossterm>
-  <glosssee otherterm="obs.glos.link"/>
+  <glosssee otherterm="obs-glos-link"/>
  </glossentry>
- <glossentry xml:id="obs.gloss.source_package">
+ <glossentry xml:id="obs-gloss-source-package">
   <glossterm>Source Package</glossterm>
   <glossdef>
    <para>
@@ -897,20 +897,20 @@
     An example of source packages are SRPMs which contain the source for
     accompanying &rpmf; binary packages.
    </para>
-   <glossseealso otherterm="obs.glos.project_binary"/>
-   <glossseealso otherterm="obs.glos.archive"/>
+   <glossseealso otherterm="obs-glos-project-binary"/>
+   <glossseealso otherterm="obs-glos-archive"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.sourceservice">
+ <glossentry xml:id="obs-glos-sourceservice">
   <glossterm>Source Service</glossterm>
   <glossdef>
    <para>
     A tool to validate, generate, or modify a source in a trustable way.
    </para>
-   <glossseealso otherterm="obs.glos.source"/>
+   <glossseealso otherterm="obs-glos-source"/>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.susepackagehub">
+ <glossentry xml:id="obs-glos-susepackagehub">
   <glossterm>&suse; Package Hub</glossterm>
   <glossdef>
    <para>
@@ -920,14 +920,14 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.systemstatus" condition="tbd">
+ <glossentry xml:id="obs-glos-systemstatus" condition="tbd">
   <glossterm>System Status</glossterm>
   <glossdef>
    <para/>
    <remark>TBD</remark>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.submitrequest">
+ <glossentry xml:id="obs-glos-submitrequest">
   <glossterm>Submit Request</glossterm>
   <glossdef>
    <para>
@@ -935,17 +935,17 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.subproject">
+ <glossentry xml:id="obs-glos-subproject">
   <glossterm>Subproject</glossterm>
   <glossdef>
    <para>A child of a parent project.</para>
-   <glossseealso otherterm="obs.glos.develproject"/>
-   <glossseealso otherterm="obs.glos.homeproject"/>
-   <glossseealso otherterm="obs.glos.project"/>   
+   <glossseealso otherterm="obs-glos-develproject"/>
+   <glossseealso otherterm="obs-glos-homeproject"/>
+   <glossseealso otherterm="obs-glos-project"/>   
   </glossdef>
  </glossentry>
  <!-- ############## T ############## -->
- <glossentry xml:id="obs.glos.target">
+ <glossentry xml:id="obs-glos-target">
   <glossterm>Target</glossterm>
   <glossdef>
    <para>
@@ -956,20 +956,20 @@
   </glossdef>
  </glossentry>
  <!-- ############## U ############## -->
- <glossentry xml:id="obs.glos.update_project">
+ <glossentry xml:id="obs-glos-update-project">
   <glossterm>Update Project</glossterm>
   <glossdef>
    <para> A project which provides official updates for the products generated
-    in the <xref linkend="obs.glos.ga_project"/>. The update project usually
+    in the <xref linkend="obs-glos-ga-project"/>. The update project usually
     links sources and repositories against the <xref
-     linkend="obs.glos.ga_project"/>.
+     linkend="obs-glos-ga-project"/>.
    </para>
-   <glossseealso otherterm="obs.glos.release_project"/>
-   <glossseealso otherterm="obs.glos.ga_project"/>
+   <glossseealso otherterm="obs-glos-release-project"/>
+   <glossseealso otherterm="obs-glos-ga-project"/>
   </glossdef>
  </glossentry>
  <!-- ############## V ############## -->
- <glossentry xml:id="obs.glos.vm_image">
+ <glossentry xml:id="obs-glos-vm-image">
   <glossterm>Virtual Machine Image</glossterm>
   <glossdef>
    <para>
@@ -978,12 +978,12 @@
     computer and run as-is. As such, there is some overlap between virtual
     machine images and appliances.
    </para>
-   <glossseealso otherterm="obs.glos.os_image"/>
-   <glossseealso otherterm="obs.glos.image"/>
+   <glossseealso otherterm="obs-glos-os-image"/>
+   <glossseealso otherterm="obs-glos-image"/>
   </glossdef>
  </glossentry>
  <!-- ############## W ############## -->
- <glossentry xml:id="obs.glos.watchlist">
+ <glossentry xml:id="obs-glos-watchlist">
   <glossterm>Watchlist</glossterm>
   <glossdef>
    <para>
@@ -992,11 +992,11 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="obs.glos.workingcopy">
+ <glossentry xml:id="obs-glos-workingcopy">
   <glossterm>Working Copy</glossterm>
-  <glosssee otherterm="obs.glos.workingdirectory"/>
+  <glosssee otherterm="obs-glos-workingdirectory"/>
  </glossentry>
- <glossentry xml:id="obs.glos.workingdirectory">
+ <glossentry xml:id="obs-glos-workingdirectory">
   <glossterm>Working Directory</glossterm>
   <glossdef>
    <para>
@@ -1007,7 +1007,7 @@
   </glossdef>
  </glossentry>
  <!-- ############## Z ############## -->
- <glossentry xml:id="obs.glos.zypper">
+ <glossentry xml:id="obs-glos-zypper">
   <glossterm>&zypper;</glossterm>
   <glossdef>
    <para>

--- a/xml/obs_image_templates.xml
+++ b/xml/obs_image_templates.xml
@@ -3,14 +3,14 @@
    <!ENTITY % entities SYSTEM "entity-decl.ent">
    %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.image_templates"
+<chapter version="5.1" xml:id="cha-obs-image-templates"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Image Templates</title>
  <info/>
  &image_template_introduction_paragraph;
- <!--<para xml:id="image_template_introduction_paragraph"> Image templates are
+ <!--<para xml:id="image-template-introduction-paragraph"> Image templates are
   pre-configured image configurations. The <link
    xlink:href="https://build.opensuse.org/image_templates">image templates page
   </link> provides a list of these templates. Users can clone these templates
@@ -23,7 +23,7 @@
    containing image sources, a config.sh file and the &kiwi; configuration XML
    file. </para>
   &image_template_icon_paragraph;
-  <!--<para xml:id="image_template_icon_paragraph"> In addition, you can define an
+  <!--<para xml:id="image-template-icon-paragraph"> In addition, you can define an
    icon for your image templates by adding graphical image (for example, PNG,
    JPG) to your template sources and name it <command>_icon</command>. If that
    file exists, it will be used as icon for your image on the image templates

--- a/xml/obs_image_templates.xml
+++ b/xml/obs_image_templates.xml
@@ -30,7 +30,7 @@
    page. </para>-->
   <note>
    <para> For more information about &kiwi; images, see <xref
-     linkend="_kiwi_appliance"/>. </para>
+     linkend="kiwi-appliance"/>. </para>
   </note>
  </sect1>
  <sect1>
@@ -50,7 +50,7 @@
    templates. </para>
   <para>
    For more information about interconnects, see
-   <xref linkend="_managing_build_targets"/>.
+   <xref linkend="managing-build-targets"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/obs_local_building.xml
+++ b/xml/obs_local_building.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha-obs-building"
+<chapter version="5.1" xml:id="cha-obs-local-building"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,8 +12,8 @@
  <info>
   <abstract>
    <para>
-      Every build which happens on the server can also be executed locally in the same environment using
-      the osc tool. All what you need is to checkout the source code and build the build recipe. The 
+      Every build that happens on the server can also be executed locally in the same environment using
+      the osc tool. All you need is to check out the source code and run <command>osc build</command> to run the build recipe. The
       following explains it for RPM format, but it works for any. osc will download needed binaries
       and execute the local build.
    </para>
@@ -21,8 +21,19 @@
  </info>
  <remark>toms 2017-08-18: Also integrate content from obs_build_containers.xml</remark>
  
- <sect1 xml:id="sec-obs-building-generic">
-  <title>Generic build options</title>
+ <sect1 xml:id="sec-obs-local-building-generic">
+  <title>Generic Local Build Options</title>
+  <para>
+     Frequently, local builds are undertaken on local checkouts of source packages that
+     already reside on an &obsa; server - for example, to test changes before commiting
+     them to the server.
+  </para>
+  <para>
+     It is also possible to trigger a local build in an arbitrary local directory containing
+     sources, without any corresponding source package on an &obsa; server. (However, osc
+     will still need a connection to the server in order to download build dependencies.)
+     The following text describes what the source directory should contain, at a minimum.
+  </para>
   <para>
      Independent of the build format you need at least one source file as build description.
      The file name and structure is format specific. You can find some supported formats described below.
@@ -49,8 +60,9 @@
    </listitem>
   </itemizedlist>
   <para>
-   For existing packages, this is already the case. To build an
-   existing package, the general procedure is as follows:</para>
+   In the typical case of source packages locally checked out from an &obsa;
+   server, this is already the case. To build an existing package, the general
+   procedure is as follows:</para>
   <procedure>
    <step>
     <para>
@@ -83,8 +95,8 @@
    </step>
    <step>
     <para>
-     The simplest way to run a build is just to call the build command. osc will try
-     to detect your installed OS and build for it if possible.
+     The simplest way to run a build is just to call the <command>osc build</command>
+     command. osc will try to detect your installed OS and build for it if possible.
     </para>
     <screen>&prompt.user;<command>osc</command> build</screen>
     <para>
@@ -95,8 +107,7 @@
    </step>
    <step>
     <para>
-	It will download the required dependencies and execute the build script. Therefore it needs to ask for root 
-	permissions in most cases.
+	It will download the required dependencies and execute the build script. Therefore it needs to ask for root permissions in most cases.
     </para>
     <variablelist>
      <varlistentry>
@@ -141,8 +152,8 @@ The buildroot was: /var/tmp/build-root/openSUSE_Tumbleweed-x86_64</screen>
   </procedure>
  </sect1>
 
- <sect1 xml:id="sec-obs-building-advanced">
-  <title>Advanced Build Environment Handling</title>
+ <sect1 xml:id="sec-obs-local-building-advanced">
+  <title>Advanced Local Build Environment Handling</title>
   <para>
 	  The default build environment for local builds is usually chroot. While this is simplest environment
 	  and is therefore easy and fast to handle, it has also a number of shortcomings. For one it is

--- a/xml/obs_maintenance_setup.xml
+++ b/xml/obs_maintenance_setup.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.maintenance_setup"
+<chapter version="5.1" xml:id="cha-obs-maintenance-setup"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -50,23 +50,23 @@
    start the maintenance process via doing a "maintenance" request. </para>
   <itemizedlist>
    <listitem>
-    <para> openSUSE:11.4 is the <xref linkend="obs.glos.ga_project"/> in
+    <para> openSUSE:11.4 is the <xref linkend="obs-glos-ga-project"/> in
      this example. It is locked and not changing anymore. </para>
    </listitem>
    <listitem>
     <para> openSUSE:11.4:Update is the <xref
-      linkend="obs.glos.update_project"/> to release official updates for the
+      linkend="obs-glos-update-project"/> to release official updates for the
       locked openSUSE:11.4 project.
       Thus it links to the openSUSE:11.4 project, inheriting all package sources from there. </para>
    </listitem>
    <listitem>
     <para> openSUSE:Maintenance is the <xref
-      linkend="obs.glos.maintenance_project"/> which in this case maintains
+      linkend="obs-glos-maintenance-project"/> which in this case maintains
       the openSUSE:11.4:Update project (and optionally others as well). </para>
    </listitem>
    <listitem>
     <para> openSUSE:Maintenance:IDxxx is a <xref
-      linkend="obs.glos.incident"/> project created automatically by accepting a
+      linkend="obs-glos-incident"/> project created automatically by accepting a
       maintenance request. </para>
    </listitem>
   </itemizedlist>
@@ -76,17 +76,17 @@
   <para>All workflow related projects must be set up with a proper project meta configuration.</para>
   <itemizedlist>
    <listitem>
-    <para>It is recommended to lock the <xref linkend="obs.glos.ga_project"/> by the project maintainer
+    <para>It is recommended to lock the <xref linkend="obs-glos-ga-project"/> by the project maintainer
         by using the <command>osc lock [PROJECT]</command> command</para>
    </listitem>
    <listitem>
-    <para> The <xref linkend="obs.glos.update_project"/> has to have the &lt;link project="[PROJECT]"/&gt;
+    <para> The <xref linkend="obs-glos-update-project"/> has to have the &lt;link project="[PROJECT]"/&gt;
     element in the project meta configuration. </para>
     <para> It is very useful to define groups of bugowners, maintainers and reviewers and to make use of bots
     for further quality assurance tasks.</para>
    </listitem>
    <listitem>
-    <para> The <xref linkend="obs.glos.maintenance_project"/> has to have the</para>
+    <para> The <xref linkend="obs-glos-maintenance-project"/> has to have the</para>
     <screen>&lt;project name=... kind="maintenance"&gt;</screen>
     <para>attribute in the project meta configuration, as well as a</para>
     <screen>&lt;maintenance&gt;</screen>
@@ -118,8 +118,8 @@
    <screen><command>osc branch --maintenance openSUSE:12.1 glibc</command>
 <command>osc branch -M -c openSUSE:12.1 glibc</command></screen>
     <para>In a simple setup as described before, create the maintenance branch
-    from the package of the <xref linkend="obs.glos.update_project"/> as the
-    <xref linkend="obs.glos.ga_project"/> can never be changed anymore. </para>
+    from the package of the <xref linkend="obs-glos-update-project"/> as the
+    <xref linkend="obs-glos-ga-project"/> can never be changed anymore. </para>
    <para> NOTE: both branch commands do support the --noaccess parameter, which
     will create a hidden project. This may be used when a not yet publicly
     known security issue is get fixed. </para>

--- a/xml/obs_moderation.xml
+++ b/xml/obs_moderation.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.moderation"
+<chapter version="5.1" xml:id="cha-obs-moderation"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -189,7 +189,7 @@
       <title>How To Moderate?</title>
       <para>
         As a moderator you can click on the yellow warning about reports, usually displayed close to the element.
-        There, you can read all the reports and make a <xref linkend="obs.glos.moderation_decision"/>. Write the reason why you agree (Favor) or disagree (Cleared).
+        There, you can read all the reports and make a <xref linkend="obs-glos-moderation-decision"/>. Write the reason why you agree (Favor) or disagree (Cleared).
       </para>
 
       <figure>
@@ -245,12 +245,12 @@
           </listitem>
         </itemizedlist>
       <para>
-        Most of these actions are reversible. Read section <xref linkend="reverting_moderators_actions"/>.
+        Most of these actions are reversible. Read section <xref linkend="reverting-moderators-actions"/>.
       </para>
     </sect2>
   </sect1>
 
-  <sect1 xml:id="reverting_moderators_actions">
+  <sect1 xml:id="reverting-moderators-actions">
     <title>Reverting Moderator's Actions</title>
     <para>
       Most of these actions are reversible except for removing a comment.
@@ -269,7 +269,7 @@
     </para>
     <para>
       In case the moderator changes their mind, they can revert the actions they made.
-      Read section <xref linkend="reverting_moderators_actions"/>.
+      Read section <xref linkend="reverting-moderators-actions"/>.
     </para>
 
     <figure>

--- a/xml/obs_motivation.xml
+++ b/xml/obs_motivation.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<preface version="5.1" xml:id="cha.obs.motivation"
+<preface version="5.1" xml:id="cha-obs-motivation"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -14,7 +14,7 @@
   </para>
  </info>
 
- <sect1 xml:id="sec.obs.motivation">
+ <sect1 xml:id="sec-obs-motivation">
   <title>Motivation</title>
   <para>
    The basic challenge when distributing Free and Open Source Software
@@ -39,7 +39,7 @@
   </para>
  </sect1>
 
- <sect1 xml:id="sec.obs.goals">
+ <sect1 xml:id="sec-obs-goals">
   <title>Goals and Target Groups for &obsa;</title>
   <para> The goals of the OBS are oriented towards the three groups of people
    that use it: </para>
@@ -67,7 +67,7 @@
    </listitem>
   </itemizedlist>
 
-  <sect2 xml:id="sec.obs.goals.packagers">
+  <sect2 xml:id="sec-obs-goals-packagers">
    <title>Automated Software Builds for Packagers</title>
    <para>
     For people who contribute to the Free Software community by packaging
@@ -78,7 +78,7 @@
    </para>
   </sect2>
 
-  <sect2 xml:id="sec.obs.goals.isv">
+  <sect2 xml:id="sec-obs-goals-isv">
    <title>Reproducibility for Free Software Projects and Independent Software Vendors (ISV)</title>
    <para> &obsa; emphasizes on making builds reproducible. It builds packages in
     a jailed environment that &obsa; sets up from scratch each time. When the
@@ -99,7 +99,7 @@
    </para>
   </sect2>
 
-  <sect2 xml:id="sec.obs.goals.users">
+  <sect2 xml:id="sec-obs-goals-users">
    <title>Easy Access to Software for Users</title>
    <para> The OBS aims to make it easy for users to download the latest version
     of software as binary packages for their operating system. They do not have

--- a/xml/obs_multibuild.xml
+++ b/xml/obs_multibuild.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.multibuild"
+<chapter version="5.1" xml:id="cha-obs-multibuild"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_notifications.xml
+++ b/xml/obs_notifications.xml
@@ -4,7 +4,7 @@
    %entities;
 ]>
 
-<chapter version="5.1" xml:id="cha.obs.notifications"
+<chapter version="5.1" xml:id="cha-obs-notifications"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -35,7 +35,7 @@
   notifications and mark them as read, improving your OBS workflow experience.
  </para>
 
- <sect1 xml:id="cha.obs.notifications.notifications_configuration">
+ <sect1 xml:id="cha-obs-notifications-notifications-configuration">
   <title>Notifications Configuration</title>
   <para>
    Click on the "Manage Your Notifications" link to define which notifications
@@ -86,7 +86,7 @@
   </figure>
  </sect1>
 
- <sect1 xml:id="cha.obs.notifications.where_can_we_find_the_notifications">
+ <sect1 xml:id="cha-obs-notifications-where-can-we-find-the-notifications">
   <title>Where Can We Find the Notifications?</title>
   <para>
    At the top right corner of every page, you will find a link to your
@@ -105,7 +105,7 @@
   </figure>
  </sect1>
 
- <sect1 xml:id="cha.obs.notifications.notifications_content">
+ <sect1 xml:id="cha-obs-notifications-notifications-content">
   <title>Notifications Content</title>
   <para>
    After clicking on the "Notifications" link, you will see a list of your most
@@ -128,7 +128,7 @@
   </para>
  </sect1>
 
- <sect1 xml:id="cha.obs.notifications.mark_notifications_as_read_or_unread">
+ <sect1 xml:id="cha-obs-notifications-mark-notifications-as-read-or-unread">
   <title>Mark Notification as Read or Unread</title>
   <para>
    Once you read a notification and possibly take action, you can mark it as
@@ -198,7 +198,7 @@
   </para>
  </sect1>
 
- <sect1 xml:id="cha.obs.notifications.notifications_filters">
+ <sect1 xml:id="cha-obs-notifications-notifications-filters">
   <title>Notifications Filters</title>
   <para>
    Filters help you in focusing your attention on a subset of your
@@ -287,7 +287,7 @@
    </listitem>
   </itemizedlist>
  </sect1>
- <sect1 xml:id="cha.obs.notifications.api">
+ <sect1 xml:id="cha-obs-notifications-api">
    <title>API</title>
    <para>
      Every user can check their unread notifications by querying:

--- a/xml/obs_osc.xml
+++ b/xml/obs_osc.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.osc"
+<chapter version="5.1" xml:id="cha-obs-osc"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -19,7 +19,7 @@
  <remark>toms 2017-08-16:  http://docserv.suse.de/documents/Open_Build_Service/obs-best-practices/html/cha.obs.best-practices.oscexamples.html#id17157
  osc, the Python command line client</remark>
 
- <sect1 xml:id="sec.obs.osc.install">
+ <sect1 xml:id="sec-obs-osc-install">
   <title>Installing and Configuring<!-- the &osc; CLI Tool--></title>
   <remark>toms 2017-08-17: Integrate some sections/text from here http://docserv.suse.de/documents/Open_Build_Service/obs-best-practices/html/cha.obs.best-practices.localsetup.html
   </remark>
@@ -43,7 +43,7 @@
    <filename>~/bin</filename> directory, and make the file executable.</para>
  </sect1>
 
- <sect1 xml:id="sec.osc.config">
+ <sect1 xml:id="sec-osc-config">
   <title>Configuring &osc;</title>
   <para>Usually, the default configuration is appropriate in most cases.
    There are some special configuration option which might be helpful
@@ -147,10 +147,10 @@
   </variablelist>
  </sect1>
 
- <sect1 xml:id="sec.osc.usage">
+ <sect1 xml:id="sec-osc-usage">
   <title>Usage</title>
   <para></para>
-  <sect2 xml:id="sec.osc.help">
+  <sect2 xml:id="sec-osc-help">
    <title>Getting Help</title>
    <para>
     <!--Before you work with &osccmd; it is useful to know how to get help.-->
@@ -164,7 +164,7 @@
   </para>
   </sect2>
   <!-- From obs_best_practice_osc_examples.xml -->
-  <sect2 xml:id="sec.osc.firsttime">
+  <sect2 xml:id="sec-osc-firsttime">
    <title>Using &osccmd; for the First Time</title>
    <para>
     When you use the &osccmd; command for the first time, the command will
@@ -206,7 +206,7 @@
     authenticated it.
    </para>
   </sect2>
-  <sect2 xml:id="sec.osc.examples">
+  <sect2 xml:id="sec-osc-examples">
    <title>Overview of Brief Examples</title>
   <para>
    The &osccmd; command is similar to <command>git</command>:
@@ -236,7 +236,7 @@
       Which &obsa; instance it shows depends on the option <option>apiurl</option>
       in the configuration file. By default, the &opensuse; Build Server
       is used. If you need another server, use the <option>-A</option>
-      option as shown in <xref linkend="sec.osc.config"/>.
+      option as shown in <xref linkend="sec-osc-config"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/obs_package_formats.xml
+++ b/xml/obs_package_formats.xml
@@ -176,7 +176,7 @@
  </sect1>
 -->
 
- <sect1 xml:id="_kiwi_appliance">
+ <sect1 xml:id="kiwi-appliance">
   <title>&kiwi; Appliance</title>
   <para>
    <link xlink:href="https://github.com/OSInside/kiwi">KIWI</link> is an OS

--- a/xml/obs_package_formats.xml
+++ b/xml/obs_package_formats.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.package_formats"
+<chapter version="5.1" xml:id="cha-obs-package-formats"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -286,7 +286,7 @@ systemctl enable sshd</screen>
   <remark>toms 2017-08-18: TODO What is it and what is needed</remark>
  </sect1>
 
- <sect1 xml:id="sec.pkgfmt.flatpak">
+ <sect1 xml:id="sec-pkgfmt-flatpak">
   <title>&flatpak;</title>
   <para>
   The <link xlink:href="https://flatpak.org/">Flatpak</link> format can be used
@@ -418,7 +418,7 @@ Support: kmod-compat kernel-default perl-YAML-LibYAML
   </example>
  </sect1>
 
- <sect1 xml:id="sec.pkgfmt.mkosi">
+ <sect1 xml:id="sec-pkgfmt-mkosi">
   <title>mkosi</title>
   <para>
    <link xlink:href="https://github.com/systemd/mkosi/">Mkosi</link> allows

--- a/xml/obs_preface.xml
+++ b/xml/obs_preface.xml
@@ -17,10 +17,6 @@
  </para>
  <para>
   This guide does not focus on a specific &obsa; version.
-  <remark>
-   That is hogwash: It just documents whatever was available at the time of
-   writing. - sknorr, 2017-08-23
-  </remark>
   It is also not a replacement of the documentation inside of the <link
    xlink:href="https://en.opensuse.org/Portal:Build_Service"
   >&opensuse; Wiki</link>. However, content from the wiki may be included in

--- a/xml/obs_product_building.xml
+++ b/xml/obs_product_building.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.product_building"
+<chapter version="5.1" xml:id="cha-obs-product-building"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_qa_hooks.xml
+++ b/xml/obs_qa_hooks.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.qa_hooks"
+<chapter version="5.1" xml:id="cha-obs-qa-hooks"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_request_and_review_system.xml
+++ b/xml/obs_request_and_review_system.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.request_and_review_system"
+<chapter version="5.1" xml:id="cha-obs-request-and-review-system"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_scheduling_and_dispatching.xml
+++ b/xml/obs_scheduling_and_dispatching.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.build_scheduling_and_dispatching"
+<chapter version="5.1" xml:id="cha-obs-build-scheduling-and-dispatching"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/xml/obs_scm_bridge.xml
+++ b/xml/obs_scm_bridge.xml
@@ -3,7 +3,7 @@
 <!ENTITY % entities SYSTEM "entity-decl.ent">
 %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.scm_bridge"
+<chapter version="5.1" xml:id="cha-obs-scm-bridge"
          xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -14,10 +14,10 @@
          xmlns:ns="http://docbook.org/ns/docbook">
   <title>SCM Bridge</title>
 
-  <sect1 xml:id="sec.obs.obs_scm_bridge">
+  <sect1 xml:id="sec-obs-obs-scm-bridge">
     <title>SCM Bridge</title>
 
-    <sect2 xml:id="sec.obs.obs_scm_bridge.setup.introduction">
+    <sect2 xml:id="sec-obs-obs-scm-bridge-setup-introduction">
       <title>Introduction</title>
 
       <para>The SCM bridge allows the sources of a single package or an entire project
@@ -44,7 +44,7 @@
       allow OBS to follow the sources automatically.</para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_bridge.setup.package">
+    <sect2 xml:id="sec-obs-obs-scm-bridge-setup-package">
       <title>Setup a package using the scm bridge</title>
 
       <para>The setup is purely done in package meta by defining the SCM URL inside of the scmsync tag:</para>
@@ -67,7 +67,7 @@
       </para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_bridge.setup.project">
+    <sect2 xml:id="sec-obs-obs-scm-bridge-setup-project">
       <title>Setup an entire project using the SCM bridge</title>
 
       <para>An entire project can be setup by defining the scmsync tag in project meta data. Every top level
@@ -85,7 +85,7 @@
          <screen>&lt;scmsync&gt;https://gitlab.com/some/repository?onlybuild=glibc&amp;onlybuild=kernel&lt;/scmsync&gt;</screen>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_bridge.implementation_and_limitations">
+    <sect2 xml:id="sec-obs-obs-scm-bridge-implementation-and-limitations">
       <title>Implementation and Limitations</title>
 
       <para>The sources are currently cloned for the OBS source server to allow OBS to process them. This
@@ -112,7 +112,7 @@
        </para>
               <screen>&lt;scmsync&gt;https://gitlab.com/some/repository?subdir=MY_SUBDIRECTORY&lt;/scmsync&gt;</screen>
 
-      <sect3 xml:id="sec.obs.obs_scm_bridge.setup.specials.revision">
+      <sect3 xml:id="sec-obs-obs-scm-bridge-setup-specials-revision">
         <title>Using a specific revision, tag or branch</title>
 
         <para>The URL can define a revision, tag or branch via an URL fragment. This means the URL can get extended by a
@@ -126,7 +126,7 @@
         </para>
 </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_bridge.setup.specials.pbuild">
+      <sect3 xml:id="sec-obs-obs-scm-bridge-setup-specials-pbuild">
         <title>Converting to a project git</title>
         <para>A project git repository is mostly the same as any project for the pbuild tool. The command </para>
         <screen># osc create-pbuild-config</screen>
@@ -137,7 +137,7 @@
         </para>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_bridge.setup.specials.fork">
+      <sect3 xml:id="sec-obs-obs-scm-bridge-setup-specials-fork">
         <title>Forking a scmsync package</title>
         <para>The OBS server allows to create a cloned project with another package using a specified
         SCM repository. This can be used by tooling to create forked test builds for merge requests.
@@ -148,11 +148,11 @@
       </sect3>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_bridge.update_notifications">
+    <sect2 xml:id="sec-obs-obs-scm-bridge-update-notifications">
       <title>SCM Source Updates</title>
 
       <para>The OBS instance needs to get notified on any change in the SCM server. There are two ways to achieve this.
-      One way is via single configurations for each git repository as documented in the <xref linkend="sec.obs.sserv.token_usage"/> documentation.
+      One way is via single configurations for each git repository as documented in the <xref linkend="sec-obs-sserv-token-usage"/> documentation.
       An alternative way is to configure it globally. This requires admin permissions on the git hosting side
       and another bridge implementation. The advantage is that any used repository will be synced automatically just
       by referencing it via the scmsync meta tag.

--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -3,7 +3,7 @@
 <!ENTITY % entities SYSTEM "entity-decl.ent">
 %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.scm_ci_workflow_integration"
+<chapter version="5.1" xml:id="cha-obs-scm-ci-workflow-integration"
          xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
          xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -14,10 +14,10 @@
          xmlns:ns="http://docbook.org/ns/docbook">
   <title>SCM/CI Workflow Integration</title>
 
-  <sect1 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup">
+  <sect1 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup">
     <title>SCM/CI Workflow Integration Setup</title>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.introduction">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-introduction">
       <title>Introduction</title>
 
       <para>With this integration, you can take advantage of source code management (SCM)
@@ -33,11 +33,11 @@
       constantly mentioning all the names for the same things, e.g. <emphasis>Pull Requests/Merge Requests</emphasis>,
       is tiresome and confusing. However, every aspect has its
       correspondence in GitLab and Gitea. Refer to <xref
-      linkend="sec.obs.obs_scm_ci_workflow_integration.setup.equivalence_table"/>
+      linkend="sec-obs-obs-scm-ci-workflow-integration-setup-equivalence-table"/>
       for clarification of terminology.</para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.prerequisites">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-prerequisites">
       <title>Prerequisites</title>
 
       <para>Before you start, you need to</para>
@@ -53,7 +53,7 @@
       </itemizedlist>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.supported_scms">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-supported-scms">
       <title>Supported SCMs</title>
 
       <para>We support the GitHub.com and GitLab.com instances.</para>
@@ -63,13 +63,13 @@
       with that SCM.</para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication">
       <title>Token Authentication</title>
 
       <para>OBS and GitHub need to talk to each other. Tokens are the way to
       make this happen.</para>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_obs_with_scm">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-obs-with-scm">
         <title>How to Authenticate OBS with SCMs</title>
 
         <para>You have to create a GitHub <emphasis role="bold">personal
@@ -115,14 +115,14 @@
         documentation to learn how.</para>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-scm-with-obs">
         <title>How to Authenticate SCMs with OBS</title>
 
          <para>You have to create an OBS <emphasis role="bold">workflow
         token</emphasis>. Github is going to use it to trigger actions on
         OBS on your behalf.</para>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs.create_token">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-scm-with-obs-create-token">
           <title>Create Token</title>
 
           <para>You can create the OBS token via WebUI in <emphasis>Profile
@@ -144,14 +144,14 @@
 
           <para>Make sure you replace <emphasis>long_ascii_salad</emphasis>
           with your real GitHub personal access token created in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_obs_with_scm"/></para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-obs-with-scm"/></para>
 
           <warning>
             <para>Don't forget to keep your token secret to prevent someone
             else from triggering operations in your name!</para></warning>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs.revoke_regenerate_token">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-scm-with-obs-revoke-regenerate-token">
           <title>Regenerating Secrets and Deleting Tokens</title>
 
           <para>If you suspect your OBS token secret was leaked, you can regenerate
@@ -174,19 +174,19 @@
           <screen language="xml"><command>osc</command> token --delete $token_id # remove the token with the given id</screen>
 
           <para>Then you can create a new one as explained in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs"/>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication-how-to-authenticate-scm-with-obs"/>
           and replace it wherever you use it.</para>
         </sect4>
       </sect3>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks">
       <title>Webhooks</title>
 
       <para>Once OBS and GitHub are allowed to speak to each other, they can
       start talking via <emphasis role="bold">webhooks</emphasis>.</para>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks.scm_events">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks-scm-events">
         <title>SCM Events</title>
 
         <para>On a GitHub repository, events are happening all the time: a
@@ -264,7 +264,7 @@
           </listitem>
         </itemizedlist>
 
-        <para>Refer to the <xref  xrefstyle="select:title" linkend="sec.obs.obs_scm_ci_workflow_integration.setup.equivalence_table"/> for more details or read more about <link
+        <para>Refer to the <xref  xrefstyle="select:title" linkend="sec-obs-obs-scm-ci-workflow-integration-setup-equivalence-table"/> for more details or read more about <link
         xlink:href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads">GitHub
         events</link>, <link
         xlink:href="https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html">GitLab
@@ -274,7 +274,7 @@
         events</link>.</para>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks.how_to_set_up_a_webhook_on_github">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks-how-to-set-up-a-webhook-on-github">
         <title>How to Set Up a Webhook on Github</title>
 
         <para>Go to the project you want to set the integration on, then under
@@ -322,7 +322,7 @@
         </itemizedlist>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks.how_to_set_up_a_webhook_on_gitlab">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks-how-to-set-up-a-webhook-on-gitlab">
         <title>How to Set Up a Webhook on GitLab</title>
 
         <para>Go to the project you want to set the integration on, under
@@ -362,7 +362,7 @@
         </itemizedlist>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks.how_to_set_up_a_webhook_on_gitea">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks-how-to-set-up-a-webhook-on-gitea">
         <title>How to Set Up a Webhook on Gitea</title>
 
         <para>Go to the repository you want to set the integration on, then under
@@ -411,7 +411,7 @@
       </sect3>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows">
       <title>OBS Workflows</title>
 
       <para>A GitHub event occurs and OBS receives the corresponding webhook.
@@ -427,7 +427,7 @@
       a directory <emphasis>.obs</emphasis> which contains a file called
       <emphasis>workflows.yml</emphasis>. If you don't want to use that
       directory, you should check
-      <xref  xrefstyle="select:title" linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.config_location"/> out.</para>
+      <xref  xrefstyle="select:title" linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-config-location"/> out.</para>
 
       <para>
         The content of <emphasis>.obs/workflows.yml</emphasis> could look
@@ -465,7 +465,7 @@ rebuild_master:
       only:
         - master</screen>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.config_location">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-config-location">
         <title>Configuration File Location</title>
 
         <para>By default the configuration file is fetched from the repository's
@@ -498,7 +498,7 @@ rebuild_master:
         </figure>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.steps">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-steps">
         <title>OBS Workflow Steps</title>
 
         <para>We support the following steps (the keys used in the
@@ -540,7 +540,7 @@ rebuild_master:
           branch a package, link packages, configure repositories/architectures, rebuild packages and trigger services of a package.</para>
         </warning>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.branch_a_package">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-branch-a-package">
           <title>Branch a Package in a Project</title>
 
           <para>Given we have a source package called<emphasis>
@@ -581,7 +581,7 @@ rebuild_master:
         configure_repositories step, set the <emphasis>add_repositories</emphasis> key to anything else than <emphasis>enabled</emphasis>.</para>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.submit_request">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-submit-request">
           <title>Submit a Request</title>
 
           <para>The submit request step is the equivalent of the <emphasis>osc submitrequest</emphasis> command.</para>
@@ -628,7 +628,7 @@ rebuild_master:
         description: 'Check out this cool package'   # (optional, uses the commit/pull request message if not set)</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.link_a_package_to_a_project">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-link-a-package-to-a-project">
           <title>Link a Package to a Project</title>
 
           <para>The link package step is the equivalent of <emphasis>osc
@@ -670,13 +670,13 @@ rebuild_master:
         target_project: home:jane</screen>
 
           <note>
-            <para>If you rely on <xref  xrefstyle="select:title" linkend="cha.obs.source_service"/>
+            <para>If you rely on <xref  xrefstyle="select:title" linkend="cha-obs-source-service"/>
             to run, for instance to pick up changes from a PR with the <emphasis>obs_scm</emphasis> service, you can't make use of this step.
             Package links do not run the services. Use the <emphasis>branch_package</emphasis> step instead.</para>
           </note>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.configure_repositories_architectures_for_a_project">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-configure-repositories-architectures-for-a-project">
           <title>Configure Repositories/Architectures for a Project</title>
 
           <para>Given a project called <emphasis>home:jane</emphasis>, the step will
@@ -741,7 +741,7 @@ rebuild_master:
               - x86_64</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.rebuild_a_package">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-rebuild-a-package">
           <title>Rebuild a Package</title>
 
           <para>Given a project called <emphasis>home:Admin</emphasis> and a
@@ -758,12 +758,12 @@ rebuild_master:
         package: ctris</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.set_flags">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-set-flags">
           <title>Set Flags for Projects, Packages, Repositories or Architectures</title>
 
           <para>There are OBS-wide defaults for each flag type. This step is
           only necessary if you want to diverge from the defaults (see
-          <xref linkend="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.set_flags.type"/>).</para>
+          <xref linkend="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-set-flags-type"/>).</para>
 
           <para>Providing the type <emphasis>build</emphasis>, the status <emphasis>enable</emphasis> and the project <emphasis>home:Admin</emphasis>, OBS will
           enable <emphasis>all</emphasis> builds:</para>
@@ -797,7 +797,7 @@ rebuild_master:
           <emphasis>set_flags</emphasis> step, although this isn't necessary as long as they exist.</para>
 
           <para>The type has to be one of the following values:</para>
-          <itemizedlist xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.set_flags.type">
+          <itemizedlist xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-set-flags-type">
             <title>Valid flag types</title>
             <listitem><para>lock (default status <emphasis>disable</emphasis>)</para></listitem>
             <listitem><para>build (default status <emphasis>enable</emphasis>)</para></listitem>
@@ -831,7 +831,7 @@ rebuild_master:
             architecture: x86_64</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.steps.trigger_services">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-trigger-services">
           <title>Trigger Services of a Package</title>
 
           <para>Given a project called <emphasis>home:Admin</emphasis> and a
@@ -851,7 +851,7 @@ rebuild_master:
         </sect4>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.filters">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-filters">
         <title>Filters</title>
 
         <para>You can customize when workflows run by declaring
@@ -874,7 +874,7 @@ rebuild_master:
         - master
         - staging</screen>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.filters.delimiters">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-filters-delimiters">
           <title>Filters Delimiters: only and ignore</title>
 
           <para>Some steps can affect a group of elements (branches)
@@ -930,11 +930,11 @@ rebuild_master:
         - staging</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.filters.event_filter">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-event-filter">
           <title>Event Filter</title>
 
           <para>Setting an event filter will run the workflow only for this event. The event filter doesn't accept multiple events.
-          Documentation on the SCM events can be found here: <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks.scm_events"/>.</para>
+          Documentation on the SCM events can be found here: <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks-scm-events"/>.</para>
 
           <para>The available event filters are:</para>
 
@@ -946,7 +946,7 @@ rebuild_master:
 
             <listitem>
               <para><emphasis role="bold">merge_request</emphasis> is an alias for the
-              'pull_request' event. Introduced with workflow version 1.1 (also see <xref linkend="sec.obs.obs_scm_ci_workflow_integration.workflow_version_table"/>).
+              'pull_request' event. Introduced with workflow version 1.1 (also see <xref linkend="sec-obs-obs-scm-ci-workflow-integration-workflow-version-table"/>).
               .</para>
             </listitem>
 
@@ -974,7 +974,7 @@ rebuild_master:
     event: pull_request</screen>
         </sect4>
 
-        <sect4 xml:id="sec.obs.obs_scm_ci_workflow_integration.obs_workflows.filters.branches_filter">
+        <sect4 xml:id="sec-obs-obs-scm-ci-workflow-integration-obs-workflows-filters-branches-filter">
           <title>Branches Filter</title>
 
           <para>Matches target branches based on their names and runs a
@@ -997,7 +997,7 @@ rebuild_master:
         - final </screen>
 
           <para>Learn more about <xref  xrefstyle="select:title"
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.filters.delimiters"/>.</para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-filters-delimiters"/>.</para>
 
           <note>
             <para>
@@ -1008,7 +1008,7 @@ rebuild_master:
         </sect4>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.placeholder_variables">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-placeholder-variables">
         <title>Placeholder Variables</title>
 
         <para>With placeholder variables, workflows are now dynamic. Whenever a
@@ -1057,11 +1057,11 @@ test_build:
 
         <para>For a more in-depth example in combination with configuration file
         location, refer to
-        <xref linkend="sec.obs.obs_scm_ci_workflow_integration.use_cases.config_url_and_placeholder_variables"/>.</para>
+        <xref linkend="sec-obs-obs-scm-ci-workflow-integration-use-cases-config-url-and-placeholder-variables"/>.</para>
       </sect3>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.status_reporting">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-status-reporting">
       <title>Status Reporting</title>
 
       <para>Once all the steps in the workflow are done, OBS will report the build results back to GitHub.</para>
@@ -1102,7 +1102,7 @@ test_build:
       </note>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.workflow_runs">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-workflow-runs">
       <title>Workflow Runs</title>
 
       <para>For every SCM event, OBS compiles relevant information about the workflows running on the system. You can find the
@@ -1172,7 +1172,7 @@ test_build:
       the workflow run will record error messages. And reading the artifacts will help to understand what happened behind the scenes.</para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.errors">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-errors">
       <title>Errors</title>
 
       <table>
@@ -1225,7 +1225,7 @@ test_build:
       </table>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.equivalence_table">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-equivalence-table">
       <title>Equivalence Table</title>
 
       <table>
@@ -1282,7 +1282,7 @@ test_build:
     </sect2>
   </sect1>
 
-  <sect1 xml:id="sec.obs.obs_scm_ci_workflow_integration.setup.event_action_and_status_report_table">
+  <sect1 xml:id="sec-obs-obs-scm-ci-workflow-integration-setup-event-action-and-status-report-table">
     <title>SCM/CI Workflow Steps Reference Table</title>
     <para>For each step, this table shows which event on the SCM will trigger which operations on the OBS.</para>
 
@@ -1510,7 +1510,7 @@ test_build:
     </table>
   </sect1>
 
-  <sect1 xml:id="sec.obs.obs_scm_ci_workflow_integration.versions">
+  <sect1 xml:id="sec-obs-obs-scm-ci-workflow-integration-versions">
     <title>SCM/CI Workflow Versions</title>
     <para>To secure the compatibility of SCM/CI workflows with new features and changes,
     we are introducing those through new versions. We specify them with a <emphasis
@@ -1532,7 +1532,7 @@ test_build:
             target_project: home:jane:playground
     </screen>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.workflow_version_table">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-workflow-version-table">
       <title>Workflow Version Table</title>
       <para>Current available workflow versions and the introduced changes can be found
       in the versions table below.</para>
@@ -1561,10 +1561,10 @@ test_build:
     </sect2>
   </sect1>
 
-  <sect1 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases">
+  <sect1 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases">
     <title>SCM/CI Workflow Integration Use-Cases</title>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.service">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-service">
       <title>OBS SCM Service</title>
 
       <para>For some of the use cases, you might want the OBS package to get
@@ -1578,7 +1578,7 @@ test_build:
       it.</para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.test_build_pull_request">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-test-build-pull-request">
       <title>Test Build a Package For Every Pull Request on GitHub</title>
 
       <para>You decide to manage your package sources from a GitHub
@@ -1586,7 +1586,7 @@ test_build:
       sources by opening a pull request, you need to verify that your package
       still builds for certain repositories and architectures in OBS. You can
       have the best of both worlds with the <xref xrefstyle="select:title"
-      linkend="sec.obs.obs_scm_ci_workflow_integration.setup"/>.</para>
+      linkend="sec-obs-obs-scm-ci-workflow-integration-setup"/>.</para>
 
       <para>You will need:</para>
 
@@ -1612,24 +1612,24 @@ test_build:
         <listitem>
           <para>The required tokens to allow OBS and GitHub talk each other as
           explained in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication"/></para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication"/></para>
         </listitem>
 
         <listitem>
           <para>The required webhooks so GitHub notifies OBS of any event as
           explained in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks"/></para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks"/></para>
         </listitem>
       </itemizedlist>
 
       <para>This is obviously a good candidate to use the <xref xrefstyle="select:title"
-      linkend="sec.obs.obs_scm_ci_workflow_integration.use_cases.service"/>.</para>
+      linkend="sec-obs-obs-scm-ci-workflow-integration-use-cases-service"/>.</para>
 
       <para>There are two different strategies to do this: <emphasis
       role="bold">branching</emphasis> the package or <emphasis
       role="bold">linking</emphasis> to it.</para>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.test_build_pull_request.branch">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-test-build-pull-request-branch">
         <title>Branch</title>
 
         <para>If you decide to branch the package for the test build, the
@@ -1658,12 +1658,12 @@ test_build:
         package will be deleted.</para>
 
         <para>Read <xref xrefstyle="select:title"
-        linkend="sec.obs.obs_scm_ci_workflow_integration.setup"/> and,
+        linkend="sec-obs-obs-scm-ci-workflow-integration-setup"/> and,
         specifically, the workflow steps (<xref
-        linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.steps"/>).</para>
+        linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-steps"/>).</para>
       </sect3>
 
-      <sect3 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.test_build_pull_request.link_configure_repositories">
+      <sect3 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-test-build-pull-request-link-configure-repositories">
         <title>Link and Configure Repositories</title>
 
         <para>If you prefer to link the package for the test build, the
@@ -1704,13 +1704,13 @@ test_build:
         flexibility to decide which repositories are you interested in.</para>
 
         <para>Read <xref xrefstyle="select:title"
-        linkend="sec.obs.obs_scm_ci_workflow_integration.setup"/> and,
+        linkend="sec-obs-obs-scm-ci-workflow-integration-setup"/> and,
         specifically, the workflow steps (<xref
-        linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.steps"/>).</para>
+        linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-steps"/>).</para>
       </sect3>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.rebuild_package_for_every_change">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-rebuild-package-for-every-change">
       <title>Rebuild a Package for Every Change in a Branch</title>
 
       <para>You have a test build set up and you want it to keep up to date
@@ -1733,18 +1733,18 @@ test_build:
         <listitem>
           <para>The required tokens to allow OBS and GitHub talk each other as
           explained in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication"/></para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication"/></para>
         </listitem>
 
         <listitem>
           <para>The required webhooks so GitHub notifies OBS of any event as
           explained in <xref
-          linkend="sec.obs.obs_scm_ci_workflow_integration.setup.webhooks"/></para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-setup-webhooks"/></para>
         </listitem>
 
         <listitem>
           <para>The source code synchronization setup with the <xref xrefstyle="select:title"
-          linkend="sec.obs.obs_scm_ci_workflow_integration.use_cases.service"/>.</para>
+          linkend="sec-obs-obs-scm-ci-workflow-integration-use-cases-service"/>.</para>
         </listitem>
       </itemizedlist>
 
@@ -1759,7 +1759,7 @@ test_build:
     event: push</screen>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.set_flags">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-set-flags">
       <title>Set Flags on a Package to Disable Builds for an Architecture</title>
 
       <para>When you branch a package, all its repositories and their architectures will be copied over.
@@ -1784,7 +1784,7 @@ test_build:
       <para></para>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.create_package_releases_with_tags">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-create-package-releases-with-tags">
       <title>Create Package on OBS for Every Software Release With Git Tags</title>
 
       <para>You have a software project for which you mark releases with Git tags. For every release, you want to create
@@ -1795,7 +1795,7 @@ test_build:
       versioned releases to another project on OBS if you need it as a dependency.</para>
 
       <para>After the usual setup for
-      OBS workflows with tokens and webhooks (see <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup"/>), you will need:</para>
+      OBS workflows with tokens and webhooks (see <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup"/>), you will need:</para>
 
       <itemizedlist>
         <listitem>
@@ -1894,7 +1894,7 @@ test_build:
       </itemizedlist>
     </sect2>
 
-    <sect2 xml:id="sec.obs.obs_scm_ci_workflow_integration.use_cases.config_url_and_placeholder_variables">
+    <sect2 xml:id="sec-obs-obs-scm-ci-workflow-integration-use-cases-config-url-and-placeholder-variables">
       <title>Using a Custom Configuration File URL in Combination with Placeholder Variables</title>
 
       <para>It may happen that you have multiple repositories following the same
@@ -1934,14 +1934,14 @@ test_build:
 
       <para>From here the only thing left to do would be to host this file
       somewhere where OBS can access it, creating a workflow token and the
-      corresponding webhooks (following the setup instructions at <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication"/>)
+      corresponding webhooks (following the setup instructions at <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup-token-authentication"/>)
       for every SCM repository you want this configuration file to apply to,
-      making sure you set the correct configuration url (see <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.config_location"/>).</para>
+      making sure you set the correct configuration url (see <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-config-location"/>).</para>
 
       <para>There are many other ways to use these two features in parallel,
       make sure to read
-      <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.placeholder_variables"/>
-      and <xref linkend="sec.obs.obs_scm_ci_workflow_integration.setup.obs_workflows.config_location"/>
+      <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-placeholder-variables"/>
+      and <xref linkend="sec-obs-obs-scm-ci-workflow-integration-setup-obs-workflows-config-location"/>
       to get some inspiration on how you can use them in your project.</para>
     </sect2>
   </sect1>

--- a/xml/obs_scm_ci_workflow_integration.xml
+++ b/xml/obs_scm_ci_workflow_integration.xml
@@ -670,7 +670,7 @@ rebuild_master:
         target_project: home:jane</screen>
 
           <note>
-            <para>If you rely on <xref  xrefstyle="select:title" linkend="cha-obs-source-service"/>
+            <para>If you rely on <xref xrefstyle="select:title" linkend="cha-obs-source-services"/>
             to run, for instance to pick up changes from a PR with the <emphasis>obs_scm</emphasis> service, you can't make use of this step.
             Package links do not run the services. Use the <emphasis>branch_package</emphasis> step instead.</para>
           </note>

--- a/xml/obs_signing.xml
+++ b/xml/obs_signing.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.signing"
+<chapter version="5.1" xml:id="cha-obs-signing"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/obs_source_management.xml
+++ b/xml/obs_source_management.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.source_management"
+<chapter version="5.1" xml:id="cha-obs-source-management"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -54,7 +54,7 @@
    <para>
      OBS 2.11 can produce and publish additional SPDX data for certain build types.
      This is controlled via the project configuration. For details, refer to
-     <xref linkend="sec.prjconfig.syntax"/> for
+     <xref linkend="sec-prjconfig-syntax"/> for
      <literal>sbom:FORMAT</literal> (under <literal>BuildFlags</literal>).
    </para>
  </sect1>

--- a/xml/obs_source_service.xml
+++ b/xml/obs_source_service.xml
@@ -3,14 +3,14 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.source_service"
+<chapter version="5.1" xml:id="cha-obs-source-service"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Using Source Services</title>
  <info/>
 
- <sect1 xml:id="sec.obs.sserv.about">
+ <sect1 xml:id="sec-obs-sserv-about">
   <title>About Source Service</title>
   <para>
    Source Services are tools to validate, generate or modify sources in a
@@ -81,7 +81,7 @@
   </itemizedlist>
   <para>
    For using source services you need (refer to <xref
-    linkend="ex.obs.sserv.struct"/>):
+    linkend="ex-obs-sserv-struct"/>):
   </para>
   <itemizedlist>
    <listitem>
@@ -101,34 +101,34 @@
     </para>
    </listitem>
   </itemizedlist>
-  <example xml:id="ex.obs.sserv.struct">
+  <example xml:id="ex-obs-sserv-struct">
    <title>Structure of a <filename>_service</filename> File</title>
-  <screen language="xml">&lt;services&gt; <co xml:id="co.obs.sserv.struct.services"/>
- &lt;service name="<replaceable>MY_SCRIPT</replaceable>"<co xml:id="co.obs.sserv.struct.name"/> mode="<replaceable>MODE</replaceable>"<co xml:id="co.obs.sserv.struct.mode"/>&gt;
-  &lt;param name="<replaceable>PARAMETER1</replaceable>"&gt;<replaceable>PARAMETER1_VALUE</replaceable>&lt;/param&gt;<co xml:id="co.obs.sserv.struct.param"/>
+  <screen language="xml">&lt;services&gt; <co xml:id="co-obs-sserv-struct-services"/>
+ &lt;service name="<replaceable>MY_SCRIPT</replaceable>"<co xml:id="co-obs-sserv-struct-name"/> mode="<replaceable>MODE</replaceable>"<co xml:id="co-obs-sserv-struct-mode"/>&gt;
+  &lt;param name="<replaceable>PARAMETER1</replaceable>"&gt;<replaceable>PARAMETER1_VALUE</replaceable>&lt;/param&gt;<co xml:id="co-obs-sserv-struct-param"/>
  &lt;/service&gt;
 &lt;/services&gt;</screen>
    <calloutlist>
-    <callout arearefs="co.obs.sserv.struct.services">
+    <callout arearefs="co-obs-sserv-struct-services">
      <para>
       The root element of a <filename>_service</filename> file.
      </para>
     </callout>
-    <callout arearefs="co.obs.sserv.struct.name">
+    <callout arearefs="co-obs-sserv-struct-name">
      <para>
       The service name. The service is a script that is stored in the
       <filename>/usr/lib/obs/service</filename> directory.
      </para>
     </callout>
-    <callout arearefs="co.obs.sserv.struct.mode">
+    <callout arearefs="co-obs-sserv-struct-mode">
      <para>
-      Mode of the service, see <xref linkend="sec.obs.sserv.mode"/>.
+      Mode of the service, see <xref linkend="sec-obs-sserv-mode"/>.
      </para>
     </callout>
-    <callout arearefs="co.obs.sserv.struct.param">
+    <callout arearefs="co-obs-sserv-struct-param">
      <para>
       One or more parameters which are passed to the script defined in
-      <xref linkend="co.obs.sserv.struct.name"/>.
+      <xref linkend="co-obs-sserv-struct-name"/>.
      </para>
     </callout>
    </calloutlist>
@@ -142,7 +142,7 @@
   services from /usr/lib/obs/service/?</remark>
  </sect1>
 
- <sect1 xml:id="sec.obs.sserv.mode">
+ <sect1 xml:id="sec-obs-sserv-mode">
   <title>Modes of Services</title>
   <para> Each service can be used in a mode defining when it should run
    and how to use the result. This can be done per package or globally for an
@@ -192,7 +192,7 @@
      </row>
      <row>
       <entry><literal>buildtime</literal></entry>
-      <entry>During each build before calling the build tool (for example, rpm-build)<footnote xml:id="fn.obs.sserv.mode.buildtime">
+      <entry>During each build before calling the build tool (for example, rpm-build)<footnote xml:id="fn-obs-sserv-mode-buildtime">
        <para>
         A side effect is that the service package is becoming a build
         dependency and must be available.
@@ -298,7 +298,7 @@
   </variablelist>
  </sect1>
 
- <sect1 xml:id="sec.obs.sserv.validate">
+ <sect1 xml:id="sec-obs-sserv-validate">
   <title>Defining Services for Validation</title>
   <para>
    Source Services can be used to validate sources. This can be defined
@@ -351,7 +351,7 @@
   </itemizedlist>
  </sect1>
 
- <sect1 xml:id="sec.obs.sserv.create">
+ <sect1 xml:id="sec-obs-sserv-create">
   <title>Creating Source Service Definitions</title>
   <para>
    Source services are defined in the <filename>_service</filename> file
@@ -397,7 +397,7 @@
   </orderedlist>
  </sect1>
 
- <sect1 xml:id="sec.obs.sserv.remove">
+ <sect1 xml:id="sec-obs-sserv-remove">
   <title>Removing a Source Service</title>
   <para> Sometimes it is useful to continue working on generated files
    manually. In this situation the <filename>_service</filename> file needs
@@ -408,16 +408,16 @@
     <command>osc service merge</command>. </para>
  </sect1>
 
- <sect1 xml:id="sec.obs.sserv.token_usage">
+ <sect1 xml:id="sec-obs-sserv-token-usage">
   <title>Trigger a service run via a webhook</title>
   <para>You may want to update sources in &obs; whenever they change in a SCM
         system. You can create a token which allows to trigger a specific
         package update and use it via a webhook. It is recommended to create
         a token for a specific package and not a wildcard token.
-        Read <xref linkend="cha.obs.authorization.token"/> to learn how to
+        Read <xref linkend="cha-obs-authorization-token"/> to learn how to
         create a token.
   </para>
-  <sect2 xml:id="sec.obs.sserv.gitlab">
+  <sect2 xml:id="sec-obs-sserv-gitlab">
    <title>Using it on gitlab</title>
    <para>
            Go to your repository settings page in your gitlab instance. Select Integrations
@@ -432,7 +432,7 @@
   <screen>https://<replaceable>YOUR_INSTANCE</replaceable>/trigger/runservice?project=<replaceable>PROJECT</replaceable>&amp;package=<replaceable>PACKAGE</replaceable></screen>
 
   </sect2>
-  <sect2 xml:id="sec.obs.sserv.github.com">
+  <sect2 xml:id="sec-obs-sserv-github-com">
    <title>Using it on github.com</title>
    <para>
       Go to your repository settings page of your repository on github.com. Select Webhooks

--- a/xml/obs_source_services.xml
+++ b/xml/obs_source_services.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha-obs-source-service"
+<chapter version="5.1" xml:id="cha-obs-source-services"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -11,7 +11,7 @@
  <info/>
 
  <sect1 xml:id="sec-obs-sserv-about">
-  <title>About Source Service</title>
+  <title>About Source Services</title>
   <para>
    Source Services are tools to validate, generate or modify sources in a
    trustable way. They are designed as smallest possible tools and can be
@@ -23,8 +23,8 @@
   <itemizedlist>
    <listitem>
     <para>
-     Server side generated files are easy to identify and are not
-     modifiable by the user. This way other user can trust them to be
+     Server-side generated files are easy to identify and are not
+     modifiable by the user. This way, other users can trust them to be
      generated in the documented way without modifications.
     </para>
    </listitem>
@@ -40,42 +40,42 @@
    </listitem>
    <listitem>
     <para>
-     Services are runnable at any time without user commit.
+     Source services are runnable at any time without user commit.
     </para>
    </listitem>
    <listitem>
     <para>
-     Services are runnable on server and client side in the same way.
+     Source services are runnable on server and client side in the same way.
     </para>
    </listitem>
    <listitem>
     <para>
-     Services are safe. A source checkout and service run never harms
+     Source services are safe. A source checkout and service run never harms
      the system of a user.
     </para>
    </listitem>
    <listitem>
     <para>
-     Services avoid unnecessary commits.
+     Source services avoid unnecessary commits.
      This means there are no time-dependent changes. In case the package
-     already contains the same file, the newly generated file are dropped.
+     already contains the same file, the newly generated file is dropped.
     </para>
    </listitem>
    <listitem>
     <para>
-     Services running local or inside the build environment can get created,
+     Source services running local or inside the build environment can get created,
      added and used by everybody.
     </para>
    </listitem>
    <listitem>
     <para>
-     Services running in default or server side mode must be installed by
+     Source services running in default or server side mode must be installed by
      the administrator of the &obsa; server.
     </para>
    </listitem>
    <listitem>
     <para>
-     The use of a service can be defined per package or project wide.
+     The use of a source service can be defined per package or project wide.
     </para>
    </listitem>
   </itemizedlist>
@@ -143,12 +143,12 @@
  </sect1>
 
  <sect1 xml:id="sec-obs-sserv-mode">
-  <title>Modes of Services</title>
-  <para> Each service can be used in a mode defining when it should run
+  <title>Modes of Source Services</title>
+  <para> Each source service can be used in a mode defining when it should run
    and how to use the result. This can be done per package or globally for an
    entire project. </para>
   <table>
-   <title>Service Modes</title>
+   <title>Source Service Modes</title>
    <tgroup cols="4">
     <colspec colnum="1" colwidth="1*"/>
     <colspec colnum="2" colwidth="2*"/>
@@ -299,9 +299,9 @@
  </sect1>
 
  <sect1 xml:id="sec-obs-sserv-validate">
-  <title>Defining Services for Validation</title>
+  <title>Defining Source Services for Validation</title>
   <para>
-   Source Services can be used to validate sources. This can be defined
+   Source services can be used to validate sources. This can be defined
    at different levels:
   </para>
   <itemizedlist>
@@ -418,22 +418,22 @@
         create a token.
   </para>
   <sect2 xml:id="sec-obs-sserv-gitlab">
-   <title>Using it on gitlab</title>
+   <title>Creating a webhook on GitLab</title>
    <para>
-           Go to your repository settings page in your gitlab instance. Select Integrations
-           there. All what you need to fill is the URL
+        Go to your repository settings page in your gitlab instance. Select Integrations
+        there. All what you need to fill is the URL
    </para>
    <screen>https://<replaceable>YOUR_INSTANCE</replaceable>/trigger/runservice</screen>
   <para>
-           and the Secret Token. Hit the <guimenu>Add webhook</guimenu> button and you are good.
-           You may specify project and package via CGI parameters in case you created a
-           wildcard token:
+        and the Secret Token. Hit the <guimenu>Add webhook</guimenu> button and you are good.
+        You may specify project and package via CGI parameters in case you created a
+        wildcard token:
   </para>
   <screen>https://<replaceable>YOUR_INSTANCE</replaceable>/trigger/runservice?project=<replaceable>PROJECT</replaceable>&amp;package=<replaceable>PACKAGE</replaceable></screen>
 
   </sect2>
   <sect2 xml:id="sec-obs-sserv-github-com">
-   <title>Using it on github.com</title>
+   <title>Creating a webhook on GitHub</title>
    <para>
       Go to your repository settings page of your repository on github.com. Select Webhooks
       settings and create a hook via <guimenu>Add Webhook</guimenu> button. Define the payload
@@ -448,8 +448,4 @@
   </sect2>
  </sect1>
 
- <sect1 condition="tbd">
-  <title>Interfaces for Using Source Services</title>
-  <para><remark>tbd</remark></para>
- </sect1>
 </chapter>

--- a/xml/obs_staging_workflow.xml
+++ b/xml/obs_staging_workflow.xml
@@ -4,12 +4,12 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.stagingworkflow"
+<chapter version="5.1" xml:id="cha-obs-stagingworkflow"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
  <title>Staging Workflow</title>
- <sect1 xml:id="sec.obs.staging.workflow.projects">
+ <sect1 xml:id="sec-obs-staging-workflow-projects">
    <title>Working with Staging Projects</title>
    <para>
      This API provides an easy way to get information about a single or all staging projects like
@@ -17,7 +17,7 @@
      Note: To use this API, you first need to setup a staging workflow for a project.
    </para>
 
-   <sect2 xml:id="sec.obs.staging.workflow.projects.index">
+   <sect2 xml:id="sec-obs-staging-workflow-projects-index">
     <title>Overview of All Staging Projects</title>
     <para>
       This endpoint provides an overview of all staging projects for a certain project.
@@ -79,7 +79,7 @@ geeko > <command>osc</command> api '/staging/openSUSE:Factory/staging_projects/?
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.projects.show">
+  <sect2 xml:id="sec-obs-staging-workflow-projects-show">
     <title>Overview of a Single Staging Project</title>
     <para>
       This endpoint provides an overview of a single staging project.
@@ -122,7 +122,7 @@ geeko > <command>osc</command> api '/staging/openSUSE:Factory/staging_projects//
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.projects.copy">
+  <sect2 xml:id="sec-obs-staging-workflow-projects-copy">
     <title>Copy a Staging Project</title>
     <para>
       This endpoint creates a copy of a staging project. It will queue a job which is going to copy the project configuration, repositories, groups and users.
@@ -133,11 +133,11 @@ geeko > <command>osc</command> api -X POST '/staging/openSUSE:Factory/staging_pr
   </sect2>
  </sect1>
 
- <sect1 xml:id="sec.obs.staging.workflow.requests">
+ <sect1 xml:id="sec-obs-staging-workflow-requests">
   <title>Working with Requests</title>
   <para>One of the main features of the staging workflow is assigning incoming requests to different staging projects.</para>
 
-  <sect2 xml:id="sec.obs.staging.workflow.assign.request">
+  <sect2 xml:id="sec-obs-staging-workflow-assign-request">
     <title>Assign Requests into a Staging Project</title>
     <para>
       Our main project openSUSE:Factory received requests with id 1 and 2.
@@ -149,7 +149,7 @@ geeko > <command>osc</command> api -X POST '/staging/openSUSE:Factory/staging_pr
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.remove.request">
+  <sect2 xml:id="sec-obs-staging-workflow-remove-request">
     <title>Remove Requests from a Staging Project</title>
     <para>
       When we are done with testing the staging project openSUSE:Factory:Staging:A, we need to remove the requests 1 and 2 again.
@@ -160,7 +160,7 @@ geeko > <command>osc</command> api -X DELETE '/staging/openSUSE:Factory/staging_
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.staging.request">
+  <sect2 xml:id="sec-obs-staging-workflow-staging-request">
     <title>List Requests of a Staging Project</title>
     <para>Listing all requests which are currently assigned to openSUSE:Factory:Staging:A can be done with the following command.</para>
     <screen>
@@ -181,7 +181,7 @@ geeko > <command>osc</command> api '/staging/openSUSE:Factory/staging_projects/o
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.exclude.request">
+  <sect2 xml:id="sec-obs-staging-workflow-exclude-request">
     <title>Exclude Requests for a Staging Workflow</title>
     <para>
       Our main project openSUSE:Factory received requests with id 3 and 4.
@@ -192,7 +192,7 @@ geeko > <command>osc</command> api -X POST '/staging/openSUSE:Factory/excluded_r
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.unexclude.request">
+  <sect2 xml:id="sec-obs-staging-workflow-unexclude-request">
     <title>Bring Back Excluded Requests from a Staging Workflow</title>
     <para>
       The following command will stop excluding requests with id 3 and 4 for the staging workflow project openSUSE:Factory.
@@ -202,7 +202,7 @@ geeko > <command>osc</command> api -X DELETE '/staging/openSUSE:Factory/excluded
     </screen>
   </sect2>
 
-  <sect2 xml:id="sec.obs.staging.workflow.accept.staging.project">
+  <sect2 xml:id="sec-obs-staging-workflow-accept-staging-project">
     <title>Accept Staging Project</title>
     <para>
       Once all the requests are ready and the staging project has an acceptable state, the requests can be merged. In other words, the staging project can be accepted.

--- a/xml/obs_supported_formats.xml
+++ b/xml/obs_supported_formats.xml
@@ -3,7 +3,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.supported_formats"
+<chapter version="5.1" xml:id="cha-obs-supported-formats"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >
@@ -14,7 +14,7 @@
   This chapter is focusing on describing &obs; specifics of a format.
   Either limitations or extensions of &obs; builds.
  </para>
- <sect1 xml:id="sec.obs.building.spec2rpm">
+ <sect1 xml:id="sec-obs-building-spec2rpm">
   <title>Spec File Specials (RPM)</title>
   <para>
      To create an RPM package, you need a spec file.

--- a/xml/obs_user_concept.xml
+++ b/xml/obs_user_concept.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.usrconcept"
+<chapter version="5.1" xml:id="cha-obs-usrconcept"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" >

--- a/xml/osc_building.xml
+++ b/xml/osc_building.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.1" xml:id="cha.obs.building"
+<chapter version="5.1" xml:id="cha-obs-building"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -21,7 +21,7 @@
  </info>
  <remark>toms 2017-08-18: Also integrate content from obs_build_containers.xml</remark>
  
- <sect1 xml:id="sec.obs.building.generic">
+ <sect1 xml:id="sec-obs-building-generic">
   <title>Generic build options</title>
   <para>
      Independent of the build format you need at least one source file as build description.
@@ -55,7 +55,7 @@
    <step>
     <para>
      If you have not done so yet, set up your project as shown in
-     <xref linkend="sec.obs.basicworkflow.setuphome"/>.
+     <xref linkend="sec-obs-basicworkflow-setuphome"/>.
     </para>
    </step>
    <step>
@@ -141,7 +141,7 @@ The buildroot was: /var/tmp/build-root/openSUSE_Tumbleweed-x86_64</screen>
   </procedure>
  </sect1>
 
- <sect1 xml:id="sec.obs.building.advanced">
+ <sect1 xml:id="sec-obs-building-advanced">
   <title>Advanced Build Environment Handling</title>
   <para>
 	  The default build environment for local builds is usually chroot. While this is simplest environment


### PR DESCRIPTION
For SEO optimization, we need to avoid the use of dots ('.') and underscores ('_') in our xml:id values.

To be merged together with companion PR: https://github.com/openSUSE/obs-landing/pull/466