### PR TITLE
Move UG: Administration to AG: High-level Overview

### DIFF
--- a/xml/book-obs-admin-guide.xml
+++ b/xml/book-obs-admin-guide.xml
@@ -33,6 +33,7 @@
  </info>
 
  <xi:include href="obs_preface.xml"/>
+ <xi:include href="obs_ag_high_level_overview.xml"/>
  <xi:include href="obs_ag_installation_and_configuration.xml"/>
  <xi:include href="obs_ag_overview_filesystem.xml"/>
  <xi:include href="obs_ag_security_concepts.xml"/>

--- a/xml/book-obs-user-guide.xml
+++ b/xml/book-obs-user-guide.xml
@@ -115,7 +115,6 @@
  <xi:include href="obs_maintenance_setup.xml"/>
  <xi:include href="obs_binary_tracking.xml"/>
 <!-- tbd: <xi:include href="obs_cross_architecture_build.xml"/>-->
- <xi:include href="obs_admin.xml"/>
  <xi:include href="obs_scheduling_and_dispatching.xml"/>
  <xi:include href="obs_build_constraints.xml"/>
  <xi:include href="obs_build_preinstall.xml"/>

--- a/xml/obs_ag_high_level_overview.xml
+++ b/xml/obs_ag_high_level_overview.xml
@@ -7,7 +7,7 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Administration</title>
+ <title>High-level Overview</title>
  <info/>
  <para> This chapter describes the components of an OBS installation and the
   typical administration tasks for an OBS administrator. </para>


### PR DESCRIPTION
The current "Administration" chapter in the "Reference" section of the User Guide contains admin-focused content and therefore belongs in the Admin Guide.

Moreover, the Admin Guide is missing a "High-level Overview" of the Build Service, and this chapter provides it.

Fixes: https://github.com/openSUSE/obs-docu/issues/366