### PR TITLE
Change mv to cp to avoid a permission denied error

### DIFF
--- a/.github/workflows/deploy-to-obs-landing.yaml
+++ b/.github/workflows/deploy-to-obs-landing.yaml
@@ -50,7 +50,7 @@ jobs:
             ./daps2docker.sh ../DC-$doc html || exit 1
 
             rm -rf ../obs-landing/help/manuals/${doc} || exit 1
-            mv -v /tmp/daps2docker-*/$doc/html/${ROOTID} ../obs-landing/help/manuals/${doc} || exit 1
+            cp -v /tmp/daps2docker-*/$doc/html/${ROOTID} ../obs-landing/help/manuals/${doc} || exit 1
           done
       - name: build pdf
         run: |
@@ -61,7 +61,7 @@ jobs:
             ./daps2docker.sh ../DC-$doc pdf || exit 1
 
             # update pdf
-            mv -v /tmp/daps2docker-*/$doc/${ROOTID}_en.pdf ../obs-landing/files/manuals/${doc}.pdf || exit 1
+            cp -v /tmp/daps2docker-*/$doc/${ROOTID}_en.pdf ../obs-landing/files/manuals/${doc}.pdf || exit 1
           done
       - name: build epub
         run: |
@@ -72,7 +72,7 @@ jobs:
             ./daps2docker.sh ../DC-$doc epub || exit 1
 
             # update epub
-            mv -v /tmp/daps2docker-*/$doc/${ROOTID}_en.epub ../obs-landing/files/manuals/${doc}.epub || exit 1
+            cp -v /tmp/daps2docker-*/$doc/${ROOTID}_en.epub ../obs-landing/files/manuals/${doc}.epub || exit 1
           done
       - name: Commit files
         run: |


### PR DESCRIPTION
Currently `build-obs-docs` job fails on `build html` step with the error `mv: cannot move '/tmp/daps2docker-*/...' to '../obs-landing/help/manuals/obs-admin-guide': Permission denied`. 

This pr attempts to resolve this error.