### PR TITLE
xml/art-obs-beginners-guide.xml: add missing link anchor

### DIFF
--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -239,7 +239,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
      </itemizedlist>
     </listitem>
    </varlistentry>
-   <varlistentry>
+   <varlistentry xml:id="vle-obsbg-hardware-reqs">
     <term>Hardware Requirements</term>
     <listitem>
      <para>


### PR DESCRIPTION
A variablelist consisting of two entries had an xml:id tag ("link anchor") only on the first entry.

This commit adds an xml:id tag to the second entry as well.