### PR TITLE
Fix zypper install osc suggestions

### DIFF
--- a/xml/art-obs-beginners-guide.xml
+++ b/xml/art-obs-beginners-guide.xml
@@ -219,7 +219,7 @@ https://www.suse.com/communities/blog/suse-studio-integration/
         <replaceable>DISTRIBUTION</replaceable> with your distribution):
        </para>
        <screen>&prompt.root;<command>zypper</command> ar &obsrepourl;/openSUSE:/Tools/<replaceable>DISTRIBUTION</replaceable>/openSUSE:Tools.repo
-&prompt.root;<command>zypper</command> install osc</screen>
+&prompt.root;<command>zypper</command> install --recommends osc</screen>
       </listitem>
       <listitem>
        <para>

--- a/xml/obs_osc.xml
+++ b/xml/obs_osc.xml
@@ -33,7 +33,7 @@
     <command>zypper</command> command (replace
     <replaceable>DISTRI</replaceable> with your distribution): </para>
   <screen>&prompt.root;<command>zypper</command> addrepo &obsrepourl;/openSUSE:/Tools/<replaceable>DISTRI</replaceable>/openSUSE:Tools.repo
-&prompt.root;<command>zypper</command> install osc</screen>
+&prompt.root;<command>zypper</command> install --recommends osc</screen>
   <remark>toms 2017-08-16: Maybe add more information about installing
   osc on other distributions?</remark>
   <para>For other systems, use your preferred package manager.</para>


### PR DESCRIPTION
The osc package only recommends packages people usually need for working.

Fixes #424 