### PR TITLE
Include suse header in user guide

### DIFF
--- a/DC-obs-user-guide
+++ b/DC-obs-user-guide
@@ -28,5 +28,7 @@ XSLTPARAM="--param generate.logo=0"
 ## Disable share links
 XSLTPARAM+=" --param generate.share.and.print=0"
 
+XSLTPARAM+=" --param include.suse.header=1"
+
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE


### PR DESCRIPTION
Fixes https://github.com/openSUSE/obs-docu/issues/452

Before:
<img width="3207" height="859" alt="image" src="https://github.com/user-attachments/assets/fb483c92-af32-466e-9014-bd893a9f2ae2" />

After:
<img width="2962" height="1197" alt="image" src="https://github.com/user-attachments/assets/2b69ac03-cfed-4037-9bdc-ff1e3897d6ee" />
